### PR TITLE
ENSIP-16 improvement proposal by blockful

### DIFF
--- a/ensips/16.md
+++ b/ensips/16.md
@@ -3,6 +3,7 @@ description: Allows metadata to be queried on EIP-3668 enabled names
 contributors:
   - jefflau
   - makoto
+  - pikonha
 ensip:
   status: draft
   created: 2022-09-22
@@ -73,7 +74,7 @@ interface IOffChainResolver {
     // Optional. If context is dynamic, the event won't be emitted.
     event MetadataChanged(
         string name,
-        string graphqlUrl,
+        string graphqlUrl
     );
 }
 ```
@@ -121,9 +122,8 @@ const dataLocation = await.resolver.graphqlUrl()
 `Metadata` is an optional schema that indexes `MetadataChanged` event.
 
 ```graphql
-
 type Domain @entity{
-  id
+  id: ID!
   metadata: Metadata
 }
 
@@ -135,7 +135,6 @@ type Metadata @entity {
   "url of the graphql endpoint"
   graphqlUrl: String
 }
-
 ```
 
 #### L2
@@ -144,41 +143,50 @@ L2 graphql URL is discoverable via `metadata` function `graphqlUrl` field.
 Because the canonical ownership of the name exists on L1, some L2/offchain storage may choose to allow multiple entities to update the same node namespaced by `context`. When querying the domain data, the query should be filtered by `context` that is returned by `metadata`function `context` field
 
 ```graphql
+type Text {
+  key: String!
+  value: String!
+}
+
+type Address {
+  address: Bytes!
+  coinType: BigInt!
+}
+
 type Domain {
   id: ID! # concatenation of context and namehash delimited by `-`
   context: Bytes
+  owner: Bytes
   name: String
-  namehash: Bytes
-  labelName: String
+  node: Bytes
+  label: String
   labelhash: Bytes
   resolvedAddress: Bytes
-  parent: Domain
-  subdomains: [Domain]
+  parent: String
+  parentNode: Bytes
+  subdomains: [Domain!]
   subdomainCount: Int!
   resolver: Resolver!
   expiryDate: BigInt
+  registerDate: BigInt
+  isApprovedForAll: Boolean
 }
 
 type Resolver @entity {
-  id: ID! # concatenation of node, resolver address and context delimited by `-`
+  id: ID!
   node: Bytes
   context: Bytes
   address: Bytes
   domain: Domain
-  addr: Bytes
   contentHash: Bytes
-  texts: [String!]
-  coinTypes: [BigInt!]
+  texts: [Text!]
+  addresses: [Address!]
 }
 ```
 
 ## Backwards Compatibility
 
 None
-
-## Open Items
-
-- Should `owner` and `isApprovedForAll` be within graphql or should be own metadata function?
 
 ## Copyright
 


### PR DESCRIPTION
# Implement ENSIP-16: Offchain Metadata for EIP-3668 Enabled Names

This PR introduces changes to support ENSIP-16, which specifies APIs for querying metadata on EIP-3668 (CCIP Read) enabled ENS names. Key updates include:

- Addition of the `Address` and `Text` structure to avoid N+1 problems
- Addition of the `isApprovedForAll` flag that is used to control who can issue a subdomain

These changes aim to improve the user experience for EIP-3668 subdomains by providing standardized ways to retrieve important metadata of the domains stored offchain.