### PR TITLE
Fix broken link in ENSIP-13

### DIFF
--- a/ensips/13.md
+++ b/ensips/13.md
@@ -342,4 +342,4 @@ library LinkedAddress {
 The core purpose of this EIP is to enhance security and promote a safer way to authenticate wallet control and asset ownership when the main wallet is not needed and assets held by the main wallet do not need to be moved. Consider it a way to do 'read only' authentication.
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENSE.md).
+Copyright and related rights waived via [CC0]([../LICENSE.md](https://creativecommons.org/public-domain/cc0/)).

--- a/ensips/13.md
+++ b/ensips/13.md
@@ -342,4 +342,4 @@ library LinkedAddress {
 The core purpose of this EIP is to enhance security and promote a safer way to authenticate wallet control and asset ownership when the main wallet is not needed and assets held by the main wallet do not need to be moved. Consider it a way to do 'read only' authentication.
 
 ## Copyright
-Copyright and related rights waived via [CC0]([../LICENSE.md](https://creativecommons.org/public-domain/cc0/)).
+Copyright and related rights waived via [CC0](https://eips.ethereum.org/LICENSE).


### PR DESCRIPTION
ENSIP-13 was originally known as [ERC-5131](https://eips.ethereum.org/EIPS/eip-5131), where the CC0 link resolves to https://eips.ethereum.org/LICENSE

This PR updates the broken relative link to be the original ERC's license file