### PR TITLE
Add "default" chain id 0 to ENSIP-11

### DIFF
--- a/ensips/11.md
+++ b/ensips/11.md
@@ -39,9 +39,19 @@ export const convertEVMChainIdToCoinType = (chainId: number) =>{
 And to reverse the operation, bitwise-AND the coinType with `0x7fffffff`: `0x7fffffff & coinType`.
 
 ```typescript
-export const convertCoinTypeToEVMChainId = (coinType: number) =>{
-  return  (0x7fffffff & coinType) >> 0
+export function convertCoinTypeToEVMChainId(coinType: bigint): number {
+  const EVM_BIT = 0x8000_0000n;
+  if (coinType == 60n) return 1;
+  return coinType == BigInt.asUintN(32, coinType) && coinType & EVM_BIT ? Number(coinType ^ EVM_BIT)  : 0;
 }
+
+convertCoinTypeToEVMChainId(            0) = 0
+convertCoinTypeToEVMChainId(            1) = 0
+convertCoinTypeToEVMChainId(  0x8000_0000) = 0
+convertCoinTypeToEVMChainId(           60) = 1
+convertCoinTypeToEVMChainId(  0x8000_0001) = 1
+convertCoinTypeToEVMChainId(  0x8000_2105) = 8453
+convertCoinTypeToEVMChainId(0x1_8000_2105) = 0
 ```
 
 For EOAs and counterfactual contracts, a fallback address can be specified by using chain ID `0`, resulting in cointype `0x80000000`: `0x80000000` | `0`. The resolution process remains as normal with an additional step. If the initial resolution request does not yield an address, now an extra lookup shall be implemented to check for the existence of an address against the EOA chain ID. 

--- a/ensips/11.md
+++ b/ensips/11.md
@@ -2,6 +2,7 @@
 description: Introduces coinType for EVM compatible chains (amending ENSIP9).
 contributors:
   - matoken.eth
+  - katzman.base.eth
 ensip:
   status: draft
   created: 2022-01-13
@@ -13,13 +14,15 @@ Introduces coinType for EVM compatible chains (amending [ENSIP-9](https://docs.e
 
 ## Abstract
 
-This ENSIP extends [ENSIP 9 (multichain address resolution)](./9), dedicates a range of coin types for EVM compatible chains, and specifies a way to derive EVM chain IDs to the designated coin types.
+This ENSIP extends [ENSIP 9 (multichain address resolution)](https://docs.ens.domains/ensip/9), dedicates a range of coin types for EVM compatible chains, and specifies a way to derive EVM chain IDs to the designated coin types.
 
 The dedicated range uses over 0x80000000 (2147483648) which is reserved under ENSIP 9 so there will be no possibility of coin type collision with other non EVM coin types to be added in future. However, some of coin types previously allocated to EVM chain ids will be deprecated.
 
 ## Motivation
 
-The existing ENSIP 9 relies on the existence of coin types on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) which was designed to define address encoding type for deterministic wallets. As the majority of EVM compatible chains inherit the same encoding type as Ethereum, it is redundant to keep requesting the addition of EVM compatible chains into SLIP 44. This specification standardises a way to derive coinType based on [Chain ID](https://chainlist.org).
+The existing ENSIP-9 relies on the existence of coin types on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) which was designed to define address encoding type for deterministic wallets. As the majority of EVM compatible chains inherit the same encoding type as Ethereum, it is redundant to keep requesting the addition of EVM compatible chains into SLIP 44. This specification standardises a way to derive coinType based on [Chain ID](https://chainlist.org).
+
+Additionally, this specification allows a user to set an EOA/Fallback address for a name. This allows for users to set one address to be used for all EVM-compatible chains, or as a fallback for when a chain-specific address record is not set.
 
 ## Specification
 
@@ -40,6 +43,8 @@ export const convertCoinTypeToEVMChainId = (coinType: number) =>{
   return  (0x7fffffff & coinType) >> 0
 }
 ```
+
+For EOAs and counterfactual contracts, a fallback address can be specified by using chain ID `0`, resulting in cointype `0x80000000`: `0x80000000` | `0`. The resolution process remains as normal with an additional step. If the initial resolution request does not yield an address, now an extra lookup shall be implemented to check for the existence of an address against the EOA chain ID. 
 
 ### Implementation
 


### PR DESCRIPTION
The idea to use chain id 0 to represent a "default" ENSIP-11 was initially proposed in this complete ENSIP draft: #7. 

This revision to ENSIP-11 attempts to make the spec more lightweight and land it where it is most relevant. At its core, this spec introduces: 

1. The chain id 0 which represents all EVM-compatible chains. This identification has precedence given [CAIP-10](https://namespaces.chainagnostic.org/eip155/caip10#caip-10). 
2. An added step to ENSIP-11 resolution requests which requires checking the existence of a default address if a chain-specific request does not return an address. 