### PR TITLE
Fix contributor validation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
         "lint": "eslint -c .eslintrc.json --ext .ts,.tsx ./src"
     },
     "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
         "@shikijs/rehype": "^3.3.0",
         "cssnano": "^7.0.5",
         "gray-matter": "^4.0.3",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@adraffy/ens-normalize':
+        specifier: ^1.11.0
+        version: 1.11.0
       '@shikijs/rehype':
         specifier: ^3.3.0
         version: 3.3.0
@@ -110,6 +113,9 @@ importers:
         version: 5.5.4
 
 packages:
+
+  '@adraffy/ens-normalize@1.11.0':
+    resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2883,6 +2889,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.11.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
 

--- a/app/src/specs/validateFrontmatter.ts
+++ b/app/src/specs/validateFrontmatter.ts
@@ -1,6 +1,7 @@
+import { ens_normalize } from '@adraffy/ens-normalize';
 import { z } from 'zod';
 
-import { ENSNameRegex, GithubUsernameRegex } from '../util/regex';
+import { GithubUsernameRegex } from '../util/regex';
 
 export const FrontMatterZod = z.object({
     description: z.string().min(5).max(160),
@@ -8,7 +9,15 @@ export const FrontMatterZod = z.object({
         .array(
             z
                 .string()
-                .regex(ENSNameRegex)
+                // If the value has a dot, check that it's a normalized ENS name
+                .refine(
+                    (value) =>
+                        value.includes('.') && ens_normalize(value) === value,
+                    {
+                        message: 'ENS name is not normalized',
+                    }
+                )
+                // Otherwise treat it as a GitHub username
                 .or(z.string().regex(GithubUsernameRegex))
         )
         .min(1)

--- a/app/src/util/regex.ts
+++ b/app/src/util/regex.ts
@@ -1,5 +1,3 @@
-// TODO: update to be more accurate
-export const ENSNameRegex = /^[\da-z]+\.[\da-z]+$/;
 export const GithubUsernameRegex = /^[\dA-Za-z]+$/;
 
 export const ENSIPNumberMatch = /ENSIP-(\d+|[Xx]): /;


### PR DESCRIPTION
Previously, the build script checked the validity of an ENS name against a simple regular expression that didn't support subnames. Now, it validates that a contributor with a `.` is a normalized ENS name. Any contributor without a `.` is assumed to be a GitHub username.