### PR TITLE
fix: Correct typos in ENSIPs

### DIFF
--- a/ensips/19.md
+++ b/ensips/19.md
@@ -102,7 +102,7 @@ A new registrar contract will be deployed on L1 for default names.  An [ENSIP-10
 
 New registrars will be deployed per chain, but only those that post state to L1 (such as [rollups](https://ethereum.org/en/developers/docs/scaling/#rollups)) may have a corresponding ENSIP-10 wildcard resolver at `"[coinTypeAsHex].reverse"`.  
 
-Each resolver will trustlessly verify registrar lookups on the corresponding chain when `addressAsHex` is a valid EVM address.  If no name is assocated with the address, the resolver will return the default name from the default registrar.
+Each resolver will trustlessly verify registrar lookups on the corresponding chain when `addressAsHex` is a valid EVM address.  If no name is associated with the address, the resolver will return the default name from the default registrar.
 
 #### Example
 

--- a/ensips/21.md
+++ b/ensips/21.md
@@ -17,7 +17,7 @@ This standard establishes the Batch Gateway Offchain Lookup Protocol (BGOLP).
 
 ## Motivation
 
-[EIP-3668](https://eips.ethereum.org/EIPS/eip-3668) describes a serial `OffchainLookup` mechanism. To perform more than one `OffchainLookup`, lookups can be preformed in sequence using recursive calls.
+[EIP-3668](https://eips.ethereum.org/EIPS/eip-3668) describes a serial `OffchainLookup` mechanism. To perform more than one `OffchainLookup`, lookups can be performed in sequence using recursive calls.
 
 This proposal standardizes an existing ENS solution, colloquially called the "Batch Gateway", utilized first by the [`UniversalResolver`](https://etherscan.io/address/0xce01f8eee7E479C928F8919abD53E553a36CeF67#code). It is effectively [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) for `OffchainLookup` reverts.
 


### PR DESCRIPTION


### **Description:**

This PR contains minor typo fixes for a couple of ENSIP documents.

- In `ensips/19.md`, corrected `assocated` to `associated`.
- In `ensips/21.md`, corrected `preformed` to `performed`.