### PR TITLE
Add language identifiers to markdown code snippets

### DIFF
--- a/ensips/10.md
+++ b/ensips/10.md
@@ -43,7 +43,7 @@ Let:
 
 ENSIP-10-compliant ENS resolvers MAY implement the following function interface:
 
-```
+```solidity
 interface ExtendedResolver {
     function resolve(bytes calldata name, bytes calldata data) external view returns(bytes);
 }
@@ -76,7 +76,7 @@ Also note that when wildcard resolution is in use (eg, `name != currentname`), c
 
 ### Pseudocode
 
-```
+```javascript
 function getResolver(name) {
     for(let currentname = name; currentname !== ''; currentname = parent(currentname)) {
         const node = namehash(currentname);

--- a/ensips/3.md
+++ b/ensips/3.md
@@ -39,7 +39,7 @@ When called by account `x`, instructs the ENS registry to transfer ownership of 
 
 Allowing the caller to specify an owner other than themselves for the relevant node facilitates contracts that need accurate reverse ENS entries delegating this to their creators with a minimum of code inside their constructor:
 
-```
+```solidity
 reverseRegistrar.claim(msg.sender)
 ```
 
@@ -55,7 +55,7 @@ When called by account `x`, sets the resolver for the name `hex(x) + '.addr.reve
 
 A new resolver interface is defined, consisting of the following method:
 
-```
+```solidity
 function name(bytes32 node) constant returns (string);
 ```
 
@@ -69,7 +69,7 @@ Future ENSIPs may specify more record types appropriate to reverse ENS records.
 
 This registrar, written in Solidity, implements the specifications outlined above.
 
-```
+```solidity
 pragma solidity ^0.4.10;
 
 import "./AbstractENS.sol";

--- a/ensips/4.md
+++ b/ensips/4.md
@@ -49,7 +49,7 @@ Encoding type 8 indicates that the ABI can be found elsewhere, at the specified 
 
 A new resolver interface is defined, consisting of the following method:
 
-```
+```solidity
 function ABI(bytes32 node, uint256 contentType) constant returns (uint256, bytes);
 ```
 


### PR DESCRIPTION
This will make code snippets more readable on the docs like this https://docs.ens.domains/ensip/10/#pseudocode