### PR TITLE
Add ENSIP: Contract Self-Naming

### DIFF
--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -1,8 +1,8 @@
 ---
 title: Contract Self-Naming
-description: A standard for contracts to declare their own reverse names using ERC-8049 metadata
+description: A standard for contracts to declare their own reverse names using ERC-8042 Diamond Storage
 contributors:
-  - premm.eth
+  - premm.eth, raffy.eth
 ensip:
   created: "2025-11-23"
   status: draft
@@ -12,11 +12,11 @@ ensip:
 
 ## Abstract
 
-This ENSIP extends ENSIP-19 to enable contracts to declare their own reverse names using ERC-8049 contract metadata. By storing a reverse name in a known storage location via ERC-8049's Optional Diamond Storage extension, contracts can self-declare their ENS name. Any account can then register this name using the reverse registrar on L1, or using an L2 reverse registrar. This enables trustless, permissionless reverse name registration for contracts without requiring the contract deployer to perform additional registration steps.
+This ENSIP extends ENSIP-19 to enable contracts to declare their own reverse names using ERC-8042 Diamond Storage. By storing a namehash of the reverse name in a known storage location, contracts can self-declare their ENS name. Any account can then register this name using the reverse registrar on L1, or using an L2 reverse registrar. This enables trustless, permissionless reverse name registration for contracts without requiring the contract deployer to perform additional registration steps.
 
 ## Motivation
 
-Current reverse name registration requires the contract owner (when there is one) to perform a separate transaction to set the reverse name after deployment. Alternatively, the contract can make a custom external call in the constructor. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8049 metadata with predictable Diamond Storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
+Current reverse name registration requires the contract owner (when there is one) to perform a separate transaction to set the reverse name after deployment. Alternatively, the contract can make a custom external call in the constructor. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8042 Diamond Storage with predictable storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
 
 ## Specification
 
@@ -24,36 +24,18 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Contract Requirements
 
-#### ERC-8049 Implementation
+#### ERC-8042 Diamond Storage Implementation
 
-Contracts MUST implement ERC-8049 with the Optioinal Diamond Storage extension to declare their reverse name. The metadata key `"eth.ens.reverse-name"` MUST be used to store the reverse name.
+Contracts MUST use ERC-8042 Diamond Storage to declare their reverse name. The diamond storage identifier `"eth.ens.reverse-name"` MUST be used to store the reverse name.
 
-**Storage Location**: ERC-8042 defines the diamond storage slot for the ERC-8049 Optional Diamond Storage metadata mapping:
-
-```solidity
-bytes32 baseSlot = keccak256("erc8049.contract.metadata.storage");
-// = 0x7c6988a1b2cb39fbaff1c9413b7b80ed9241f1bdbe6602ef83baf9d6673fd50a
-```
-
-This slot contains a struct comprising a `mapping(string key => bytes value)` called `metadata`. The reverse name is stored at the mapping key `"eth.ens.reverse-name"`.
-
-The actual storage slot for the reverse name value is computed as:
+**Storage Location**: The storage slot is computed using ERC-8042 Diamond Storage:
 
 ```solidity
-bytes32 keyHash = keccak256(bytes("eth.ens.reverse-name"));
-bytes32 storageSlot = keccak256(abi.encode(keyHash, baseSlot));
+bytes32 storageSlot = keccak256("eth.ens.reverse-name");
+// = 0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf
 ```
 
-For the key `"eth.ens.reverse-name"`:
-```solidity
-keyHash = keccak256(bytes("eth.ens.reverse-name"))
-        = 0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf
-
-storageSlot = keccak256(abi.encode(0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf, 0x7c6988a1b2cb39fbaff1c9413b7b80ed9241f1bdbe6602ef83baf9d6673fd50a))
-            = 0x94270372dde1798328336feac81168e7d959b12f3d2497d26f9e1b935b793b3b
-```
-
-**Value Format**: The value MUST be stored as `bytes` containing the UTF-8 string representation of the ENS name (e.g., `bytes("mycontract.eth")`).
+**Value Format**: The value MUST be stored as `bytes32` containing the namehash of the ENS name.
 
 #### Setting the Reverse Name
 
@@ -63,19 +45,32 @@ Contracts MAY set their reverse name during deployment (in the constructor or in
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {ERC8049ContractMetadata} from "./ERC8049ContractMetadata.sol";
+contract MyContract {
+    bytes32 constant STORAGE_POSITION = keccak256("eth.ens.reverse-name");
 
-contract MyContract is ERC8049ContractMetadata {
+    /// @custom:storage-location erc8042:eth.ens.reverse-name
+    struct ReverseNameStorage {
+        bytes32 reverseNameHash;
+    }
+
+    function getStorage() internal pure returns (ReverseNameStorage storage s) {
+        bytes32 position = STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
     constructor() {
-        // Declare the contract's reverse name
-        _setContractMetadata("eth.ens.reverse-name", bytes("mycontract.eth"));
+        // Declare the contract's reverse name using ERC-8042 Diamond Storage
+        // Replace with ENS namehash("mycontract.eth")
+        getStorage().reverseNameHash = bytes32(0);
     }
 }
 ```
 
 ## Rationale
 
-Using ERC-8049 with its Optional Diamond Storage extension provides a standardized, low-friction method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. This standardization also ensures composability with other ERC-8049 metadata and enables efficient single-slot verification for names under 32 characters.
+Using ERC-8042 Diamond Storage provides a simple, standardized method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. By storing the namehash directly in a single slot, this approach is more gas-efficient and simpler to implement than metadata mapping approaches.
 
 ## Security Considerations
 
@@ -83,7 +78,7 @@ None.
 
 ## Backwards Compatibility
 
-This ENSIP is fully backwards compatible with ENSIP-19. Contracts without ERC-8049 implementations continue to use traditional reverse registration. L2 registrars can support both traditional registration and contract self-naming simultaneously.
+This ENSIP is fully backwards compatible with ENSIP-19. Contracts without ERC-8042 Diamond Storage implementations continue to use traditional reverse registration. L2 registrars can support both traditional registration and contract self-naming simultaneously.
 
 ## Copyright
 
@@ -92,6 +87,5 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 ## References
 
 * ENSIP-19: Multichain Primary Names
-* ERC-8049: Contract-Level Onchain Metadata
 * ERC-8042: Diamond Storage
 

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -1,5 +1,5 @@
 ---
-title: Contract Self-Naming via ERC-8049
+title: Contract Self-Naming
 description: A standard for contracts to declare their own reverse names using ERC-8049 metadata
 contributors:
   - premm.eth
@@ -8,7 +8,7 @@ ensip:
   status: draft
 ---
 
-# ENSIP-XX: Contract Self-Naming via ERC-8049
+# ENSIP-XX: Contract Self-Naming
 
 ## Abstract
 

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -8,7 +8,7 @@ ensip:
   status: draft
 ---
 
-# ENSIP-XX: Contract Self-Naming
+# ENSIP-X: Contract Self-Naming
 
 ## Abstract
 

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -1,0 +1,97 @@
+---
+title: Contract Self-Naming via ERC-8049
+description: A standard for contracts to declare their own reverse names using ERC-8049 metadata
+contributors:
+  - premm.eth
+ensip:
+  created: "2025-11-23"
+  status: draft
+---
+
+# ENSIP-XX: Contract Self-Naming via ERC-8049
+
+## Abstract
+
+This ENSIP extends ENSIP-19 to enable contracts to declare their own reverse names using ERC-8049 contract metadata. By storing a reverse name in a known storage location via ERC-8049's Optional Diamond Storage extension, contracts can self-declare their ENS name. Any account can then register this name using the reverse registrar on L1, or using an L2 reverse registrar. This enables trustless, permissionless reverse name registration for contracts without requiring the contract deployer to perform additional registration steps.
+
+## Motivation
+
+Current reverse name registration requires the contract owner or deployer to perform a separate transaction to set the reverse name after deployment. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8049 metadata with predictable Diamond Storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Contract Requirements
+
+#### ERC-8049 Implementation
+
+Contracts MUST implement ERC-8049 with the Optioinal Diamond Storage extension to declare their reverse name. The metadata key `"eth.ens.reverse-name"` MUST be used to store the reverse name.
+
+**Storage Location**: ERC-8042 defines the diamond storage slot for the ERC-8049 Optional Diamond Storage metadata mapping:
+
+```solidity
+bytes32 baseSlot = keccak256("erc8049.contract.metadata.storage");
+// = 0x7c6988a1b2cb39fbaff1c9413b7b80ed9241f1bdbe6602ef83baf9d6673fd50a
+```
+
+This slot contains a struct comprising a `mapping(string key => bytes value)` called `metadata`. The reverse name is stored at the mapping key `"eth.ens.reverse-name"`.
+
+The actual storage slot for the reverse name value is computed as:
+
+```solidity
+bytes32 keyHash = keccak256(bytes("eth.ens.reverse-name"));
+bytes32 storageSlot = keccak256(abi.encode(keyHash, baseSlot));
+```
+
+For the key `"eth.ens.reverse-name"`:
+```solidity
+keyHash = keccak256(bytes("eth.ens.reverse-name"))
+        = 0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf
+
+storageSlot = keccak256(abi.encode(0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf, 0x7c6988a1b2cb39fbaff1c9413b7b80ed9241f1bdbe6602ef83baf9d6673fd50a))
+            = 0x94270372dde1798328336feac81168e7d959b12f3d2497d26f9e1b935b793b3b
+```
+
+**Value Format**: The value MUST be ABI-encoded as `bytes` containing the UTF-8 string representation of the ENS name (e.g., `bytes("mycontract.eth")`).
+
+#### Setting the Reverse Name
+
+Contracts MAY set their reverse name during deployment (in the constructor or initialization function):
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC8049ContractMetadata} from "./ERC8049ContractMetadata.sol";
+
+contract MyContract is ERC8049ContractMetadata {
+    constructor() {
+        // Declare the contract's reverse name
+        _setContractMetadata("eth.ens.reverse-name", bytes("mycontract.eth"));
+    }
+}
+```
+
+## Rationale
+
+Using ERC-8049 with its Optional Diamond Storage extension provides a standardized, low-friction method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for DAO-controlled or ownerless contracts while maintaining security through cryptographic verification. This standardization also ensures composability with other ERC-8049 metadata and enables efficient single-slot verification.
+
+## Security Considerations
+
+None.
+
+## Backwards Compatibility
+
+This ENSIP is fully backwards compatible with ENSIP-19. Contracts without ERC-8049 implementations continue to use traditional reverse registration. L2 registrars can support both traditional registration and contract self-naming simultaneously.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## References
+
+* ENSIP-19: Multichain Primary Names
+* ERC-8049: Contract-Level Onchain Metadata
+* ERC-8042: Diamond Storage
+

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -16,7 +16,7 @@ This ENSIP extends ENSIP-19 to enable contracts to declare their own reverse nam
 
 ## Motivation
 
-Current reverse name registration requires the contract owner or deployer to perform a separate transaction to set the reverse name after deployment. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8049 metadata with predictable Diamond Storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
+Current reverse name registration requires the contract owner (when there is one) to perform a separate transaction to set the reverse name after deployment. Alternatively, the contract can make a custom external call in the constructor. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8049 metadata with predictable Diamond Storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
 
 ## Specification
 

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -53,7 +53,7 @@ storageSlot = keccak256(abi.encode(0x09ded414ae6c0ce389342caf0619071d5be1687a6f7
             = 0x94270372dde1798328336feac81168e7d959b12f3d2497d26f9e1b935b793b3b
 ```
 
-**Value Format**: The value MUST be ABI-encoded as `bytes` containing the UTF-8 string representation of the ENS name (e.g., `bytes("mycontract.eth")`).
+**Value Format**: The value MUST be stored as `bytes` containing the UTF-8 string representation of the ENS name (e.g., `bytes("mycontract.eth")`).
 
 #### Setting the Reverse Name
 
@@ -75,7 +75,7 @@ contract MyContract is ERC8049ContractMetadata {
 
 ## Rationale
 
-Using ERC-8049 with its Optional Diamond Storage extension provides a standardized, low-friction method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for DAO-controlled or ownerless contracts while maintaining security through cryptographic verification. This standardization also ensures composability with other ERC-8049 metadata and enables efficient single-slot verification.
+Using ERC-8049 with its Optional Diamond Storage extension provides a standardized, low-friction method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. This standardization also ensures composability with other ERC-8049 metadata and enables efficient single-slot verification for names under 32 characters.
 
 ## Security Considerations
 

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -62,8 +62,8 @@ contract MyContract {
 
     constructor() {
         // Declare the contract's reverse name using ERC-8042 Diamond Storage
-        // Replace with ENS namehash("mycontract.eth")
-        getStorage().reverseNameHash = bytes32(0);
+        // `namehash(...)` refers to the ENS Namehash algorithm.
+        getStorage().reverseNameHash = namehash("mycontract.eth");
     }
 }
 ```

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -1,6 +1,6 @@
 ---
 title: Contract Self-Naming
-description: A standard for contracts to declare their own reverse names using ERC-8042 Diamond Storage
+description: Two interfaces for contracts to name themselves or delegate naming authority for ENSIP-19 reverse resolution
 contributors:
   - premm.eth, raffy.eth
 ensip:
@@ -12,73 +12,86 @@ ensip:
 
 ## Abstract
 
-This ENSIP extends ENSIP-19 to enable contracts to declare their own reverse names using ERC-8042 Diamond Storage. By storing a namehash of the reverse name in a known storage location, contracts can self-declare their ENS name. Any account can then register this name using the reverse registrar on L1, or using an L2 reverse registrar. This enables trustless, permissionless reverse name registration for contracts without requiring the contract deployer to perform additional registration steps.
+This ENSIP extends [ENSIP-19](./19) with two interfaces that let contracts control their own reverse names. A contract that implements `IContractName` declares its chosen ENS name through a view function and emits a `ContractNameSet` event when that name changes, so indexers and resolvers can discover and follow the contract's name directly. A contract that implements `IContractNamer` delegates naming authority to one or more addresses through a single function dedicated to naming, generalizing the previous Ownable-only delegation pattern.
 
 ## Motivation
 
-Current reverse name registration requires the contract owner (when there is one) to perform a separate transaction to set the reverse name after deployment. Alternatively, the contract can make a custom external call in the constructor. This ENSIP enables contracts to declare their reverse ENS name during deployment using ERC-8042 Diamond Storage with predictable storage locations. Any account can then trustlessly verify the declaration and permissionlessly register the contract's reverse name in the registrar, removing the burden from contract deployers.
+Today, a contract can have its reverse name set in two main ways. The contract itself can call the reverse resolver, either on deployment from its constructor or from a later transaction. The contract can also implement the Ownable interface and let `owner()` set the name through the reverse registrar. This ENSIP adds two ENS-specific options that give contract authors more flexibility.
+
+A contract can name itself by publishing its own ENS name. The name is exposed through a view function and announced through an event, so indexers and resolvers that support this interface can discover and follow the name directly.
+
+A contract can also delegate naming authority to any address or set of addresses through a function dedicated to naming, which is independent of Ownable's broader semantics like ownership transfer, renouncement, and a privileged role over the contract's other functionality. This supports multisigs, role-based access controls, and other custom authorization patterns.
+
+Both options enable permissionless reverse name registration and let contract authors choose the lightest mechanism that fits their design.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Contract Requirements
+A contract MAY implement `IContractName`, `IContractNamer`, or both. A contract that implements either interface MUST conform to its specification below. Implementations SHOULD advertise the interface through ERC-165 for reliable detection.
 
-#### ERC-8042 Diamond Storage Implementation
+### `IContractName`
 
-Contracts MUST use ERC-8042 Diamond Storage to declare their reverse name. The diamond storage identifier `"eth.ens.reverse-name"` MUST be used to store the reverse name.
-
-**Storage Location**: The storage slot is computed using ERC-8042 Diamond Storage:
+ERC-165 interface identifier: `0x75d0c0dc`.
 
 ```solidity
-bytes32 storageSlot = keccak256("eth.ens.reverse-name");
-// = 0x09ded414ae6c0ce389342caf0619071d5be1687a6f7314e74bcc7cfa1a0df4bf
-```
+interface IContractName {
+    /// @notice Emitted when the contract's name is set or changed.
+    event ContractNameSet(string name);
 
-**Value Format**: The value MUST be stored as `bytes32` containing the namehash of the ENS name.
-
-#### Setting the Reverse Name
-
-Contracts MAY set their reverse name during deployment (in the constructor or initialization function):
-
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
-
-contract MyContract {
-    bytes32 constant STORAGE_POSITION = keccak256("eth.ens.reverse-name");
-
-    /// @custom:storage-location erc8042:eth.ens.reverse-name
-    struct ReverseNameStorage {
-        bytes32 reverseNamehash;
-    }
-
-    function getStorage() internal pure returns (ReverseNameStorage storage s) {
-        bytes32 position = STORAGE_POSITION;
-        assembly {
-            s.slot := position
-        }
-    }
-
-    constructor() {
-        // Declare the contract's reverse name using ERC-8042 Diamond Storage
-        // `namehash(...)` refers to the ENS Namehash algorithm.
-        getStorage().reverseNamehash = namehash("mycontract.eth");
-    }
+    /// @notice The unverified ENS name for this contract, e.g. "mycontract.eth".
+    function contractName() external view returns (string memory);
 }
 ```
 
+A contract implementing `IContractName` declares the ENS name it wishes to use for reverse resolution. The returned name is unverified and MUST be verified through ENSIP-19 forward resolution before it is trusted. Indexers and resolvers that support `IContractName` discover the name directly from the contract. No registration in the reverse registry is required.
+
+A contract implementing `IContractName` MUST emit `ContractNameSet(string name)` whenever the value returned by `contractName()` changes, including the initial value set at deployment.
+
+### `IContractNamer`
+
+ERC-165 interface identifier: `0x6f3ff726`.
+
+```solidity
+interface IContractNamer {
+    /// @notice Determine if an account is authorized to name this contract.
+    function isContractNamer(address namer) external view returns (bool);
+}
+```
+
+A contract implementing `IContractNamer` delegates naming authority to any address for which `isContractNamer(namer)` returns true. The reverse registrar MUST consult this function to authorize a name change request.
+
+### Reverse Registrar Behavior
+
+Because authorizing a name change has security implications, a reverse registrar MUST detect implementations of `IContractNamer` through ERC-165.
+
+When a caller submits a name change for a contract that implements `IContractNamer`, the registrar MUST call `isContractNamer(caller)` on the contract. If the call returns true, the registrar MUST set the reverse record to the supplied name.
+
+A contract MAY implement both `IContractName` and `IContractNamer`. The two paths operate independently. `IContractName` is read directly by indexers and resolvers that support it. `IContractNamer` is consulted by the reverse registrar to authorize name changes.
+
+### Precedence
+
+If both a reverse record in the reverse resolver registry and an `IContractName.contractName()` value exist for the same contract address, the reverse resolver registry takes precedence. Consumers MUST use the value from the reverse resolver registry in this case. When no reverse record is set in the reverse resolver registry, consumers MAY fall back to `IContractName.contractName()`.
+
 ## Rationale
 
-Using ERC-8042 Diamond Storage provides a simple, standardized method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. By storing the namehash directly in a single slot, this approach is more gas-efficient and simpler to implement than storing the plain string in the contract. 
+The two interfaces serve distinct trust models. `IContractName` allows a contract to declare a single canonical name with no external authorization required for registration, which fits immutable or admin-free contracts. `IContractNamer` allows a contract to delegate naming to addresses of its choice, which generalizes the previous Ownable-based pattern and accommodates multisigs, role-based access, and custom authorization logic.
+
+`IContractName` is fully self-contained. The contract publishes its name and emits an event, which indexers and resolvers that support this interface can use to discover and follow the name. No on-chain reverse-registry transaction is required. This makes self-naming the lightest mechanism for a contract to declare its identity.
+
+Separating the two interfaces keeps each one minimal and explicit. A contract that wants both flexibility and a default canonical name may implement both. A contract that is fully immutable can implement only `IContractName` and never expose a delegated naming surface.
 
 ## Security Considerations
 
-None.
+The value returned by `contractName()` is unverified. Consumers, including indexers, resolvers, and applications, MUST verify the declared name through ENSIP-19 forward resolution before treating it as a reliable identifier.
+
+Consumers SHOULD use ERC-165 to confirm that a contract implements `IContractName` or `IContractNamer` before invoking its methods. Without this check, a consumer may misinterpret a colliding function selector on a contract that does not implement this ENSIP, which for `IContractNamer` can cause a reverse registrar to incorrectly authorize a name change.
+
+`isContractNamer` is fully under the contract's control. A contract that returns true for every address effectively grants open naming authority, which may not be the intended behavior. Reverse registrars cannot detect this misconfiguration on behalf of the contract.
 
 ## Backwards Compatibility
 
-This ENSIP is fully backwards compatible with ENSIP-19. Contracts without ERC-8042 Diamond Storage implementations continue to use traditional reverse registration. L2 registrars can support both traditional registration and contract self-naming simultaneously.
+This ENSIP is fully backwards compatible with ENSIP-19. Contracts that do not implement either interface continue to use existing reverse registration flows.
 
 ## Copyright
 
@@ -87,5 +100,4 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 ## References
 
 * ENSIP-19: Multichain Primary Names
-* ERC-8042: Diamond Storage
-
+* ERC-165: Standard Interface Detection

--- a/ensips/contract-self-naming.md
+++ b/ensips/contract-self-naming.md
@@ -50,7 +50,7 @@ contract MyContract {
 
     /// @custom:storage-location erc8042:eth.ens.reverse-name
     struct ReverseNameStorage {
-        bytes32 reverseNameHash;
+        bytes32 reverseNamehash;
     }
 
     function getStorage() internal pure returns (ReverseNameStorage storage s) {
@@ -63,14 +63,14 @@ contract MyContract {
     constructor() {
         // Declare the contract's reverse name using ERC-8042 Diamond Storage
         // `namehash(...)` refers to the ENS Namehash algorithm.
-        getStorage().reverseNameHash = namehash("mycontract.eth");
+        getStorage().reverseNamehash = namehash("mycontract.eth");
     }
 }
 ```
 
 ## Rationale
 
-Using ERC-8042 Diamond Storage provides a simple, standardized method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. By storing the namehash directly in a single slot, this approach is more gas-efficient and simpler to implement than metadata mapping approaches.
+Using ERC-8042 Diamond Storage provides a simple, standardized method for contracts to declare their ENS names through predictable storage locations that enable trustless verification. This approach eliminates deployment friction by allowing contracts to self-declare their identity during initialization without requiring separate registration transactions. The permissionless registration model allows any account to complete the registration process, making it ideal for admin-free contracts while maintaining security through cryptographic verification. By storing the namehash directly in a single slot, this approach is more gas-efficient and simpler to implement than storing the plain string in the contract. 
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary

This ENSIP extends ENSIP-19 with two interfaces that let contracts control their own reverse names:

- `IContractName` (selector `0x75d0c0dc`): the contract publishes its own ENS name through `contractName()` and emits a `ContractNameSet` event when the name changes. Indexers and resolvers that support this interface can discover and follow the contract's name directly. No additional reverse-resolver registration is required.
- `IContractNamer` (selector `0x6f3ff726`): the contract delegates naming authority to one or more addresses through `isContractNamer(address)`. This generalizes the previous Ownable-only delegation pattern so multisigs, role-based access controls, and custom authorization logic can serve as the naming authority.

Both interfaces are defined in the post-audit branch of [ensdomains/contracts-v2](https://github.com/ensdomains/contracts-v2/tree/post-audit/contracts/src/reverse-registrar/interfaces).

## Precedence

When a value is registered in the reverse resolver registry and `contractName()` returns a value for the same contract, the reverse resolver registry takes precedence.

## ERC-165

ERC-165 advertisement is RECOMMENDED for both interfaces. Reverse registrars MUST detect `IContractNamer` through ERC-165 because of the security implications of selector collisions in the authorization path.

## Backwards Compatibility

Fully backwards compatible with ENSIP-19. Contracts that do not implement either interface continue to use existing reverse-registration flows.

## History

This PR replaces the prior draft, which used ERC-8042 Diamond Storage for a self-declared namehash. The new approach uses the interfaces published in `ensdomains/contracts-v2` post-audit, which were not yet defined when the original draft was written.