### PR TITLE
ENSIP-25: AI Agent Registry ENS Name Verification

### DIFF
--- a/ensips/25.md
+++ b/ensips/25.md
@@ -2,6 +2,7 @@
 description: A method for verifying ENS names for AI agent registries
 contributors:
   - premm.eth
+  - raffy.eth
 ensip:
   created: "2025-10-02"
   status: draft
@@ -11,19 +12,23 @@ ensip:
 
 ## Abstract
 
-This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using ENSIP-24 `data()` records. A name MAY publish one or more registry entries using the keys `agent-registry` and `agent-registry: N` (where `N` is an integer). This provides an explicit priority order and allows an agent to be registered in more than one registry per chain. Each record value is `bytes` and includes the full ERC-7930 address of the registry (chain + address) plus the agent ID.
+This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using text records. It enables ENS names to publish their agent registry entries in a prioritized order, supporting registration across multiple registries and chains.
+
+This ENSIP also defines a direct lookup method for verifying an ENS name from an AI agent registry without needing to iterate over lists of registry entries.
 
 ## Motivation
 
-With the introduction of AI agent registries which include ENS names for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agent IDs. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities. 
+With the introduction of AI agent registries which include ENS names, such as ERC-8004, for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agent IDs. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities.
+
+Additionally, when verifying an ENS name from an AI agent registry, clients should not need to iterate over a list of `agent-registry` entries to find a match. This ENSIP provides a direct lookup method using a parameterized text record key that includes the agent identifier.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Agent Registry Data Record Keys
+### Agent Registry Text Record Keys
 
-This ENSIP introduces ENSIP-24 `data()` records that store verification data for one AI agent registry entry.
+This ENSIP introduces text records that store verification data for one AI agent registry entry.
 
 The record keys are:
 
@@ -34,20 +39,20 @@ These keys establish a priority order: `agent-registry` is highest priority, fol
 
 The key format `agent-registry: N` uses the format specified in ERC-8119: Parameterized Storage Keys for specifying structured keys with parameters.
 
-The value returned by `data(node, key)` MUST be `bytes` containing the agent registry address and agent ID (see next section).
+### Agent Registry and Agent ID Format (ERC-8127 Token Identifier)
 
-### Agent Registry and Agent ID Format (bytes)
-
-The agent registry `data()` record contains the ERC-7930 address (including chain and address) followed by the agentID:
+The agent registry text record value uses the ERC-8127 Token Identifier format:
 
 ```
-┌─────────────────────┬──────────────────────┬───────────┐
-│ ERC-7930 address    │ AgentIDLengthInBytes │ AgentID   │
-└─────────────────────┴──────────────────────┴───────────┘
+<agentId>@<registry>
 ```
-The agent registry data record value MUST contain the raw ERC-7930 address bytes appended with a one-byte agentID length, followed by the agentID bytes.
 
-To decode the record, clients MUST parse the leading ERC-7930 address bytes according to ERC-7930. The subsequent byte is the AgentIDLengthInBytes, followed by that many bytes of AgentID.
+Where:
+
+- `<agentId>` is the numeric agent ID from the registry (decimal string)
+- `<registry>` is the ERC-7930 interoperable address of the registry contract (hexadecimal string with `0x` prefix)
+
+The ERC-8127 format also supports an optional alias prefix (`[<alias>.]<agentId>@<registry>`), but for verification purposes the alias is not required.
 
 ### Ethereum Example
 
@@ -55,18 +60,45 @@ For EVM chains, the agent registry address MUST be encoded as an ERC-7930 addres
 
 Ethereum Agent Registry (i.e. ERC-8004): `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
-The agent registry data record value contains the ERC-7930 address bytes for the registry, followed by the AgentIDLengthInBytes `0x01`, followed by the AgentID `0xa7`.
+The `agent-registry` text record value for agent ID 167 would be:
 
-The full `agent-registry` record bytes would be:
 ```
-0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa9604501a7
+167@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
 ```
 
 Where:
-- `0x00010000010114` = ERC-7930 address bytes for eip155:1 (Ethereum Mainnet) with 20-byte address (0x14)
-- `d8da6bf26964af9d7eed9e03e53415d37aa96045` = 20-byte registry address (lowercase, no 0x prefix)
-- `01` = AgentIDLengthInBytes (1 byte)
-- `a7` = AgentID (1 byte, 0xa7 = 167)
+
+- `167` = Agent ID (decimal)
+- `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` = ERC-7930 address for eip155:1 (Ethereum Mainnet) registry
+
+With an optional alias, the value could be:
+
+```
+support-agent.167@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
+```
+
+### Direct Verification via Parameterized Key
+
+To verify an ENS name from an AI agent registry without iterating over lists, this ENSIP defines a parameterized text record key format:
+
+```
+verify-agent-registry: <agentId>@<registry>
+```
+
+Where `<agentId>@<registry>` follows the ERC-8127 Token Identifier format (without the optional alias).
+
+The value of this text record can be any non-empty string. A non-empty value indicates the ENS name is verified for that specific agent registry entry. 
+
+- `1` or `true`, etc.
+
+This allows direct verification of an ENS name for a specific agent without needing to iterate through the `agent-registry`, `agent-registry: 1`, `agent-registry: 2`, etc. keys.
+
+#### Example
+
+To verify that `myagent.eth` is registered as agent 42 on a specific registry:
+
+1. Resolve the text record for key `verify-agent-registry: 42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` on `myagent.eth`
+2. If the value is non-empty, the ENS name is verified for that agent registry entry
 
 ### Verification Methods
 
@@ -77,20 +109,28 @@ This ENSIP defines two verification flows:
 When starting from an AI agent registry:
 
 1. The client MUST query the ENS name of the agent using the agent metadata
-2. The client MUST resolve the ENSIP-24 `data()` record(s) for the specified ENS name using the keys `agent-registry` and `agent-registry: N` in ascending `N` order, where the client chooses how high to check. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). The client MAY stop checking additional keys once the expected registry is found.
-3. For each record, the client MUST decode the ERC-7930 address and AgentID from the returned bytes
-4. The client MUST verify that the decoded ERC-7930 address corresponds to the expected registry (including chain)
-5. The client MUST verify that the decoded AgentID corresponds to the expected agent in the registry
+2. The client MUST resolve the text record(s) for the specified ENS name using the keys `agent-registry` and `agent-registry: N` in ascending `N` order, where the client chooses how high to check. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). The client MAY stop checking additional keys once the expected registry is found.
+3. For each record, the client MUST parse the ERC-8127 Token Identifier to extract the agent ID and registry address
+4. The client MUST verify that the parsed ERC-7930 address corresponds to the expected registry (including chain)
+5. The client MUST verify that the parsed agent ID corresponds to the expected agent in the registry
 
 #### ENS-to-Registry Verification
 
 When starting from an ENS name:
 
-1. The client MUST query the ENSIP-24 `data()` record(s) for the ENS name using the keys `agent-registry` and `agent-registry: N` (where `N` = 1, 2, 3, 4) in ascending `N` order to discover the registries the ENS name is registered with. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). An ENS name may have multiple registries, and a client MAY choose to verify one or more depending on context. For example, if a client wants to verify whether an ENS name is registered as an agent on a particular chain, it may resolve the list of registries to discover whether the agent is registered on a registry of that chain. The client MAY stop checking additional keys after finding a registry that matches its criteria.
-2. For each record, the client MUST decode the ERC-7930 address and AgentID from the returned bytes
-3. The client MUST verify that the decoded registry corresponds to an expected AI agent registry for the target chain (if applicable)
-4. The client MUST verify that the decoded AgentID corresponds to the expected agent ID in the registry
+1. The client MUST query the text record(s) for the ENS name using the keys `agent-registry` and `agent-registry: N` (where `N` = 1, 2, 3, 4) in ascending `N` order to discover the registries the ENS name is registered with. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). An ENS name may have multiple registries, and a client MAY choose to verify one or more depending on context. For example, if a client wants to verify whether an ENS name is registered as an agent on a particular chain, it may resolve the list of registries to discover whether the agent is registered on a registry of that chain. The client MAY stop checking additional keys after finding a registry that matches its criteria.
+2. For each record, the client MUST parse the ERC-8127 Token Identifier to extract the agent ID and registry address
+3. The client MUST verify that the parsed registry corresponds to an expected AI agent registry for the target chain (if applicable)
+4. The client MUST verify that the parsed agent ID corresponds to the expected agent ID in the registry
 5. The client MUST verify that the registry's claimed ENS name from the metadata of the agent matches the original ENS name
+
+#### Direct Verification (Registry-to-ENS)
+
+To verify an ENS name from an AI agent registry without iterating over lists:
+
+1. The client MUST construct the text record key: `verify-agent-registry: <agentId>@<registry>` using the ERC-8127 format
+2. The client MUST resolve this text record on the ENS name claimed by the agent
+3. If the value is non-empty, the ENS name is verified for that agent registry entry
 
 ### Registry Standards
 
@@ -100,17 +140,39 @@ This ENSIP is intended to be used for registries that use numeric IDs such as ER
 
 An ENS name can reference multiple agent registries (including multiple registries on the same chain) using prioritized keys:
 
-- `agent-registry` → primary registry entry (any chain; chain is encoded in the ERC-7930 address bytes in the value)
+- `agent-registry` → primary registry entry (any chain; chain is encoded in the ERC-7930 address in the value)
 - `agent-registry: 1` → secondary registry entry
 - `agent-registry: 2` → tertiary registry entry
 - `agent-registry: 3` → etc.
 
+Each record contains the ERC-8127 Token Identifier with the agent ID and registry address.
 
-Each record contains the ERC-7930 address of the registry (including chain and address) along with the agentID.
+**Example values:**
+
+- `agent-registry`: `42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` (Ethereum Mainnet)
+- `agent-registry: 1`: `support.100@0x0001000000890114a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (Arbitrum)
+- `agent-registry: 2`: `helper.55@0x00010000002105141234567890abcdef1234567890abcdef12345678` (Optimism)
+
+### Example Direct Verification
+
+An ENS name `myagent.eth` can enable direct verification for its agent registry entries by setting text records:
+
+- Key: `verify-agent-registry: 42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
+- Value: `true`
+- Key: `verify-agent-registry: 100@0x0001000000890114a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`
+- Value: `1`
+
+Clients verifying `myagent.eth` from a registry can directly look up the specific `verify-agent-registry` key without iterating through `agent-registry` entries.
 
 ## Rationale
 
-This ENSIP provides a standardized method for AI agent registry verification using the established ERC-7930 bytes format for chain-aware addresses and ENSIP-24 `data()` records. The design prioritizes simplicity and interoperability by using a small set of predictable keys with a defined priority order. Because each record value encodes the full ERC-7930 address (including chain), a single ENS name can reference registries across multiple chains, and can also include multiple registries on the same chain.
+This ENSIP provides two complementary methods for AI agent registry verification using the ERC-8127 Token Identifier format and ENS text records.
+
+The first method uses the `agent-registry` and `agent-registry: N` text record keys to publish a prioritized list of agent registry entries. This allows discovery of all registries an ENS name is associated with. The design prioritizes simplicity and interoperability by using a small set of predictable keys with a defined priority order. Because each record value encodes the full ERC-7930 address (including chain) as part of the ERC-8127 format, a single ENS name can reference registries across multiple chains, and can also include multiple registries on the same chain.
+
+The second method uses the `verify-agent-registry: <agentId>@<registry>` parameterized text record key to enable direct verification of an ENS name from an AI agent registry without iterating over lists. This provides a more efficient verification path when the client already knows the specific agent ID and registry address.
+
+The use of text records improves human readability and makes it easier for users to inspect and understand the verification data. The ERC-8127 format provides a consistent way to represent token identifiers that is both human readable (the agent ID portion) and machine parseable.
 
 ## Backwards Compatibility
 
@@ -123,4 +185,3 @@ None.
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -1,0 +1,118 @@
+---
+description: A method for verifying ENS names for AI agent registries
+contributors:
+  - premm.eth
+ensip:
+  created: "2025-10-02"
+  status: draft
+---
+
+# ENSIP-25: AI Agent Registry ENS Name Verification
+
+## Abstract
+
+This ENSIP defines a standardized method for verifying ENS names associated with AI Agent registries using text records with the format "agent-registry:<ERC-7930 based chain IDs>". The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
+
+## Motivation
+
+With the introduction of AI agent registries which include ENS names for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agents. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities. 
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Agent Registry Text Record
+
+This ENSIP introduces text records with the format `agent-registry:<ERC-7930 based chain ID>` that store verification data for an AI agent registry on a specific chain. The record key MUST use the format `agent-registry:` followed by an ERC-7930 address chain ID, which is an ERC-7930 Interoperable Address V1 binary format with address length 0 (no address), representing only the chain specification. The ERC-7930 based chain ID in the record key MUST be hex-encoded, all lower case, without the `0x` prefix. The value of the text record MUST be the agent registry and agent ID. 
+
+### Agent Registry and Agent ID Format
+
+The agent registry text record contains the CAIP-350 Address format followed by the agentID:
+
+```
+┌─────────────────────┬──────────────────────┬───────────┐
+│ CAIP-350 address    │ AgentIDLengthInBytes │ AgentID   │
+└─────────────────────┴──────────────────────┴───────────┘
+```
+The agent registry text record value MUST contain a hex-encoded string representing the CAIP-350 address appended with a one-byte agentID length (hex encoded all lower case without the 0x prefix), followed by the agentID bytes (hex encoded all lower case without the 0x prefix).
+
+### Ethereum Example
+
+CAIP-350 for the eip155 namespace uses EIP-55 to convert the 20-byte Ethereum address to a string. 
+
+Ethereum Agent Registry (i.e. ERC-8004): `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35901a7`
+
+The agent registry text record value contains the CAIP-350 address (text) `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359` (EIP-55 checksummed), followed by the AgentIDLengthInBytes `01` (hex encoded all lower case without the 0x prefix), followed by the AgentID `a7` (hex encoded all lower case without the 0x prefix). 
+
+Note: EIP-55 checksummed addresses use a hash scheme to specify upper and lower case letters. All lower case letters cannot be assumed.
+
+### Verification Methods
+
+This ENSIP defines two verification flows:
+
+#### Registry-to-ENS Verification
+
+When starting from an AI agent registry:
+
+1. The client MUST query the ENS name of the agent using the agent metadata
+2. The client MUST construct the ERC-7930 based chain ID format (with address length 0) for the chain
+3. The client MUST forward resolve the ENS text record `agent-registry:<ERC-7930 Chain ID>` for the specified ENS name
+4. The client MUST verify that the CAIP-350 address corresponds to the expected registry
+5. The client MUST verify that the AgentID corresponds to the expected agent in the registry
+
+#### ENS-to-Registry Verification
+
+When starting from an ENS name:
+
+1. The client MUST query the `agent-registry:<ERC-7930 base chain ID>` text record for the ENS name
+2. The client MUST verify that the registry contract is the expected AI agent registry
+3. The client MUST verify that the AgentID corresponds to the expected agent in the registry
+4. The client MUST verify that the registry's claimed ENS name from the metadata of the agent matches the original ENS name
+
+### Registry Standards
+
+Registries implementing this ENSIP SHOULD follow established standards such as ERC-8004 for AI agent registry implementations. The specific registry standard used MUST be documented and accessible to clients for proper verification.
+
+## Examples
+
+### Example Agent Registry Record
+
+For an AI agent registry on Ethereum Mainnet (EIP-155 chain ID 1) with:
+- ERC-7930 based chain ID (for key): `0x000100000100` (Ethereum Mainnet with no address, see [ERC-7930 Example 4](https://eips.ethereum.org/EIPS/eip-7930))
+- CAIP-350 Address (for value): `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359` (see [CAIP-350](https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip350.md))
+- Agent ID: `a7` (variable length, 1 byte, 0xa7 = 167)
+
+The text record key would be: `agent-registry:000100000100`
+
+The text record value would be:
+```
+0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35901a7
+```
+
+### Example Multichain Agent
+
+An ENS name can reference multiple agent registries across different chains using [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) chain ID format:
+
+- `agent-registry:000100000100` → Ethereum Mainnet (EIP-155 chain ID 1) registry
+- `agent-registry:00010000018900` → Polygon (EIP-155 chain ID 137) registry
+- `agent-registry:00010002A86A00` → Avalanche (EIP-155 chain ID 43114) registry
+- `agent-registry:000100022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef00` → Solana Mainnet registry
+
+
+Each record contains the CAIP-350 address of the registry on that specific chain along with the agentID.
+
+## Rationale
+
+This ENSIP provides a standardized method for AI agent registry verification using the established ERC-7930 bytes format for chain IDs. The design prioritizes simplicity and interoperability by using text records with variable-length agent ID encoding, enabling bidirectional verification between registries and ENS names while maintaining compatibility with existing ENS infrastructure. By including the chain specification in the record key using ERC-7930 based chain ID format, a single ENS name can reference multiple agent registries across different chains, enabling multichain agent implementations. This allows ENS names as agents to operate across multiple blockchain networks while maintaining a single ENS identity.
+
+## Backwards Compatibility
+
+This ENSIP introduces a new text record key type and does not affect existing ENS functionality. It is fully backward compatible with all existing ENS records and resolvers. Existing ENS names without agent registry text records will continue to function normally.
+
+## Security Considerations
+
+None.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -3,6 +3,8 @@ description: A method for verifying ENS names for AI agent registries
 contributors:
   - premm.eth
   - raffy.eth
+  - workemon.eth
+  - ses.eth
 ensip:
   created: "2025-10-02"
   status: draft
@@ -12,175 +14,90 @@ ensip:
 
 ## Abstract
 
-This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using text records. It enables ENS names to publish their agent registry entries in a prioritized order, supporting registration across multiple registries and chains.
-
-This ENSIP also defines a direct lookup method for verifying an ENS name from an AI agent registry without needing to iterate over lists of registry entries.
+This ENSIP defines a standardized method for directly verifying, using text records, the association between an ENS name and an AI agent identity registered in a specific on-chain AI agent registry.
 
 ## Motivation
 
-With the introduction of AI agent registries which include ENS names, such as ERC-8004, for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agent IDs. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities.
-
-Additionally, when verifying an ENS name from an AI agent registry, clients should not need to iterate over a list of `agent-registry` entries to find a match. This ENSIP provides a direct lookup method using a parameterized text record key that includes the agent identifier.
+With the introduction of on-chain AI agent identity registries, such as ERC-8004, in which agents may declare an associated ENS name, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent identity and the ENS name it claims to control. This ENSIP defines a direct lookup method using a parameterized text record key that includes a unique agent identifier.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Agent Registry Text Record Keys
+### Parameterized Verification Text Record Key
 
-This ENSIP introduces text records that store verification data for one AI agent registry entry.
-
-The record keys are:
-
-- `agent-registry`
-- `agent-registry: N` where `N` is a base-10 integer (`1`, `2`, `3`, ...) used to represent additional entries.
-
-These keys establish a priority order: `agent-registry` is highest priority, followed by `agent-registry: 1`, then `agent-registry: 2`, etc.
-
-The key format `agent-registry: N` uses the format specified in ERC-8119: Parameterized Storage Keys for specifying structured keys with parameters.
-
-### Agent Registry and Agent ID Format (ERC-8127 Token Identifier)
-
-The agent registry text record value uses the ERC-8127 Token Identifier format:
+To enable verification of an ENS name from a specific AI agent registry entry, this ENSIP defines a global parameterized ENS text record key:
 
 ```
-<agentId>@<registry>
+agent-registration[<registry>][<agentId>]
 ```
 
 Where:
 
-- `<agentId>` is the numeric agent ID from the registry (decimal string)
-- `<registry>` is the ERC-7930 interoperable address of the registry contract (hexadecimal string with `0x` prefix)
+- `<registry>` is the ERC-7930 interoperable address of the registry contract (hexadecimal string with `0x` prefix),
+- `<agentId>` is the registry-defined agent identifier (string) and MUST NOT contain the characters `[` or `]`.
 
-The ERC-8127 format also supports an optional alias prefix (`[<alias>.]<agentId>@<registry>`), but for verification purposes the alias is not required.
+The combination of `<registry>` and `<agentId>` MUST uniquely identify an agent within the context of the referenced registry.
+
+The value of this text record MUST be a non-empty string. Implementations SHOULD set the value to `"1"`. The specific value has no semantic meaning; the presence of a non-empty value is interpreted as an attestation by the ENS name owner that the ENS name is associated with the referenced AI agent registry entry. Verification clients MUST NOT depend on the specific value beyond it being non-empty.
+
+### Verification Flow (Registry-to-ENS)
+
+Clients performing verification starting from an AI agent registry entry MUST follow the steps below:
+
+1. Obtain the claimed ENS name, agent identifier, and registry address from the AI agent registry entry.
+2. Construct the text record key `agent-registration[<registry>][<agentId>]`.
+3. Resolve the text record with this key on the claimed ENS name.
+4. If the resolved value is non-empty, the ENS name is considered verified for that specific agent registry entry.
+
+If the text record does not exist or resolves to an empty value, verification MUST fail.
 
 ### Ethereum Example
 
-For EVM chains, the agent registry address MUST be encoded as an ERC-7930 address with a 20-byte address length.
+For EVM-based registries, the registry address MUST be encoded as an ERC-7930 interoperable address with a 20-byte address length.
 
-Ethereum Agent Registry (i.e. ERC-8004): `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
-
-The `agent-registry` text record value for agent ID 167 would be:
+Example registry (ERC-8004 on Ethereum mainnet):
 
 ```
-167@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
+0x8004A169FB4a3325136EB29fA0ceB6D2e539a432
 ```
 
-Where:
-
-- `167` = Agent ID (decimal)
-- `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` = ERC-7930 address for eip155:1 (Ethereum Mainnet) registry
-
-With an optional alias, the value could be:
+ERC-7930 encoding (EIP-155 chain ID 1):
 
 ```
-support-agent.167@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045
+0x000100000101148004a169fb4a3325136eb29fa0ceb6d2e539a432
 ```
 
-### Direct Verification via Parameterized Key
-
-To verify an ENS name from an AI agent registry without iterating over lists, this ENSIP defines a parameterized text record key format:
+Corresponding verification text record key for agent `167`:
 
 ```
-verify-agent-registry: <agentId>@<registry>
+agent-registration[0x000100000101148004a169fb4a3325136eb29fa0ceb6d2e539a432][167]
 ```
 
-Where `<agentId>@<registry>` follows the ERC-8127 Token Identifier format (without the optional alias).
+Any non-empty value set under this key indicates a positive verification.
 
-The value of this text record can be any non-empty string. A non-empty value indicates the ENS name is verified for that specific agent registry entry. 
+### Registry Compatibility
 
-- `1` or `true`, etc.
+This ENSIP is intended for AI agent registries that:
 
-This allows direct verification of an ENS name for a specific agent without needing to iterate through the `agent-registry`, `agent-registry: 1`, `agent-registry: 2`, etc. keys.
+- assign stable identifiers to agent registrations, and
+- allow an ENS name to be declared as part of the agent’s metadata (on-chain or off-chain).
 
-#### Example
-
-To verify that `myagent.eth` is registered as agent 42 on a specific registry:
-
-1. Resolve the text record for key `verify-agent-registry: 42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` on `myagent.eth`
-2. If the value is non-empty, the ENS name is verified for that agent registry entry
-
-### Verification Methods
-
-This ENSIP defines two verification flows:
-
-#### Registry-to-ENS Verification
-
-When starting from an AI agent registry:
-
-1. The client MUST query the ENS name of the agent using the agent metadata
-2. The client MUST resolve the text record(s) for the specified ENS name using the keys `agent-registry` and `agent-registry: N` in ascending `N` order, where the client chooses how high to check. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). The client MAY stop checking additional keys once the expected registry is found.
-3. For each record, the client MUST parse the ERC-8127 Token Identifier to extract the agent ID and registry address
-4. The client MUST verify that the parsed ERC-7930 address corresponds to the expected registry (including chain)
-5. The client MUST verify that the parsed agent ID corresponds to the expected agent in the registry
-
-#### ENS-to-Registry Verification
-
-When starting from an ENS name:
-
-1. The client MUST query the text record(s) for the ENS name using the keys `agent-registry` and `agent-registry: N` (where `N` = 1, 2, 3, 4) in ascending `N` order to discover the registries the ENS name is registered with. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). An ENS name may have multiple registries, and a client MAY choose to verify one or more depending on context. For example, if a client wants to verify whether an ENS name is registered as an agent on a particular chain, it may resolve the list of registries to discover whether the agent is registered on a registry of that chain. The client MAY stop checking additional keys after finding a registry that matches its criteria.
-2. For each record, the client MUST parse the ERC-8127 Token Identifier to extract the agent ID and registry address
-3. The client MUST verify that the parsed registry corresponds to an expected AI agent registry for the target chain (if applicable)
-4. The client MUST verify that the parsed agent ID corresponds to the expected agent ID in the registry
-5. The client MUST verify that the registry's claimed ENS name from the metadata of the agent matches the original ENS name
-
-#### Direct Verification (Registry-to-ENS)
-
-To verify an ENS name from an AI agent registry without iterating over lists:
-
-1. The client MUST construct the text record key: `verify-agent-registry: <agentId>@<registry>` using the ERC-8127 format
-2. The client MUST resolve this text record on the ENS name claimed by the agent
-3. If the value is non-empty, the ENS name is verified for that agent registry entry
-
-### Registry Standards
-
-This ENSIP is intended to be used for registries that use numeric IDs such as ERC-8004, and allow for saving an ENS name per ID as onchain or offchain metadata. The specific registry standard used MUST be documented and accessible to clients for proper verification.
-
-### Example Multichain Agent
-
-An ENS name can reference multiple agent registries (including multiple registries on the same chain) using prioritized keys:
-
-- `agent-registry` → primary registry entry (any chain; chain is encoded in the ERC-7930 address in the value)
-- `agent-registry: 1` → secondary registry entry
-- `agent-registry: 2` → tertiary registry entry
-- `agent-registry: 3` → etc.
-
-Each record contains the ERC-8127 Token Identifier with the agent ID and registry address.
-
-**Example values:**
-
-- `agent-registry`: `42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` (Ethereum Mainnet)
-- `agent-registry: 1`: `support.100@0x0001000000890114a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (Arbitrum)
-- `agent-registry: 2`: `helper.55@0x00010000002105141234567890abcdef1234567890abcdef12345678` (Optimism)
-
-### Example Direct Verification
-
-An ENS name `myagent.eth` can enable direct verification for its agent registry entries by setting text records:
-
-- Key: `verify-agent-registry: 42@0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
-- Value: `true`
-- Key: `verify-agent-registry: 100@0x0001000000890114a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`
-- Value: `1`
-
-Clients verifying `myagent.eth` from a registry can directly look up the specific `verify-agent-registry` key without iterating through `agent-registry` entries.
+Registries using this ENSIP MUST document how agent identifiers and claimed ENS names are obtained to allow clients to perform correct verification.
 
 ## Rationale
 
-This ENSIP provides two complementary methods for AI agent registry verification using the ERC-8127 Token Identifier format and ENS text records.
+This ENSIP provides a minimal verification mechanism that leverages existing ENS text records without requiring resolver upgrades or registry-specific integrations. By embedding a registry entry identifier directly into the text record key, clients can perform deterministic verification from known registry inputs using a single resolver lookup.
 
-The first method uses the `agent-registry` and `agent-registry: N` text record keys to publish a prioritized list of agent registry entries. This allows discovery of all registries an ENS name is associated with. The design prioritizes simplicity and interoperability by using a small set of predictable keys with a defined priority order. Because each record value encodes the full ERC-7930 address (including chain) as part of the ERC-8127 format, a single ENS name can reference registries across multiple chains, and can also include multiple registries on the same chain.
-
-The second method uses the `verify-agent-registry: <agentId>@<registry>` parameterized text record key to enable direct verification of an ENS name from an AI agent registry without iterating over lists. This provides a more efficient verification path when the client already knows the specific agent ID and registry address.
-
-The use of text records improves human readability and makes it easier for users to inspect and understand the verification data. The ERC-8127 format provides a consistent way to represent token identifiers that is both human readable (the agent ID portion) and machine parseable.
+The registry component is encoded as an ERC-7930 interoperable address, which combines chain identification and the registry contract address into a canonical representation, enabling unambiguous registry identification across chains.
 
 ## Backwards Compatibility
 
-No issues. 
+Not applicable.
 
 ## Security Considerations
 
-None.
+If an ENS name is transferred to a new owner, any existing verification text records may become stale. Clients SHOULD consider ENS name ownership changes when evaluating the validity of prior attestations and MAY apply additional freshness or revocation checks as appropriate.
 
 ## Copyright
 

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -11,7 +11,7 @@ ensip:
 
 ## Abstract
 
-This ENSIP defines a standardized method for verifying ENS names associated with AI Agent registries using text records with the format `agent-registry:<ERC-7930 based chain IDs>`. The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
+This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using text records with the format `agent-registry:<ERC-7930 based chain IDs>`. The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
 
 ## Motivation
 

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -32,7 +32,7 @@ The record keys are:
 
 These keys establish a priority order: `agent-registry` is highest priority, followed by `agent-registry: 1`, then `agent-registry: 2`, etc.
 
-The key format `agent-registry: N` uses the [TOON](https://github.com/toon-format/toon) format for specifying structured keys with parameters. TOON is created by Johann Schopplich ([TOON](https://github.com/toon-format/toon)).
+The key format `agent-registry: N` uses the format specified in ERC-8119: Parameterized Storage Keys for specifying structured keys with parameters.
 
 The value returned by `data(node, key)` MUST be `bytes` containing the agent registry address and agent ID (see next section).
 
@@ -124,7 +124,3 @@ None.
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-## References
-
-* ENSIP-24: Arbitrary Data Resolution
-* TOON: https://github.com/toon-format/toon

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -11,40 +11,62 @@ ensip:
 
 ## Abstract
 
-This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using text records with the format `agent-registry:<ERC-7930 based chain IDs>`. The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
+This ENSIP defines a standardized method for verifying ENS names associated with AI agent registries using ENSIP-24 `data()` records. A name MAY publish one or more registry entries using the keys `agent-registry` and `agent-registry: N` (where `N` is an integer). This provides an explicit priority order and allows an agent to be registered in more than one registry per chain. Each record value is `bytes` and includes the full ERC-7930 address of the registry (chain + address) plus the agent ID.
 
 ## Motivation
 
-With the introduction of AI agent registries which include ENS names for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agents. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities. 
+With the introduction of AI agent registries which include ENS names for each agent, there is a need for a standardized verification method. This verification process is essential for establishing trust between an AI agent registry and its claimed ENS identity. It is also necessary to be able to discover the AI agents of ENS names. ENS names also contain metadata, which we would like to verifiably associate with one or more AI agent IDs. This ENSIP provides a clear specification for discovering and verifying ENS names of AI agents, allowing for the development of human readable agent identities. 
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Agent Registry Text Record
+### Agent Registry Data Record Keys
 
-This ENSIP introduces text records with the format `agent-registry:<ERC-7930 based chain ID>` that store verification data for an AI agent registry on a specific chain. The record key MUST use the format `agent-registry:` followed by an ERC-7930 address chain ID, which is an ERC-7930 Interoperable Address V1 binary format with address length 0 (no address), representing only the chain specification. The ERC-7930 based chain ID in the record key MUST be hex-encoded, all lower case, without the `0x` prefix. The value of the text record MUST be the agent registry and agent ID. 
+This ENSIP introduces ENSIP-24 `data()` records that store verification data for one AI agent registry entry.
 
-### Agent Registry and Agent ID Format
+The record keys are:
 
-The agent registry text record contains the CAIP-350 Address format followed by the agentID:
+- `agent-registry`
+- `agent-registry: N` where `N` is a base-10 integer (`1`, `2`, `3`, ...) used to represent additional entries.
+
+These keys establish a priority order: `agent-registry` is highest priority, followed by `agent-registry: 1`, then `agent-registry: 2`, etc.
+
+The key format `agent-registry: N` uses the [TOON](https://github.com/toon-format/toon) format for specifying structured keys with parameters. TOON is created by Johann Schopplich ([TOON](https://github.com/toon-format/toon)).
+
+The value returned by `data(node, key)` MUST be `bytes` containing the agent registry address and agent ID (see next section).
+
+### Agent Registry and Agent ID Format (bytes)
+
+The agent registry `data()` record contains the ERC-7930 address (including chain and address) followed by the agentID:
 
 ```
 ┌─────────────────────┬──────────────────────┬───────────┐
-│ CAIP-350 address    │ AgentIDLengthInBytes │ AgentID   │
+│ ERC-7930 address    │ AgentIDLengthInBytes │ AgentID   │
 └─────────────────────┴──────────────────────┴───────────┘
 ```
-The agent registry text record value MUST contain a hex-encoded string representing the CAIP-350 address appended with a one-byte agentID length (hex encoded all lower case without the 0x prefix), followed by the agentID bytes (hex encoded all lower case without the 0x prefix).
+The agent registry data record value MUST contain the raw ERC-7930 address bytes appended with a one-byte agentID length, followed by the agentID bytes.
+
+To decode the record, clients MUST parse the leading ERC-7930 address bytes according to ERC-7930. The subsequent byte is the AgentIDLengthInBytes, followed by that many bytes of AgentID.
 
 ### Ethereum Example
 
-CAIP-350 for the eip155 namespace uses EIP-55 to convert the 20-byte Ethereum address to a string. 
+For EVM chains, the agent registry address MUST be encoded as an ERC-7930 address with a 20-byte address length.
 
-Ethereum Agent Registry (i.e. ERC-8004): `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35901a7`
+Ethereum Agent Registry (i.e. ERC-8004): `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
-The agent registry text record value contains the CAIP-350 address (text) `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359` (EIP-55 checksummed), followed by the AgentIDLengthInBytes `01` (hex encoded all lower case without the 0x prefix), followed by the AgentID `a7` (hex encoded all lower case without the 0x prefix). 
+The agent registry data record value contains the ERC-7930 address bytes for the registry, followed by the AgentIDLengthInBytes `0x01`, followed by the AgentID `0xa7`.
 
-Note: EIP-55 checksummed addresses use a hash scheme to specify upper and lower case letters. All lower case letters cannot be assumed.
+The full `agent-registry` record bytes would be:
+```
+0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa9604501a7
+```
+
+Where:
+- `0x00010000010114` = ERC-7930 address bytes for eip155:1 (Ethereum Mainnet) with 20-byte address (0x14)
+- `d8da6bf26964af9d7eed9e03e53415d37aa96045` = 20-byte registry address (lowercase, no 0x prefix)
+- `01` = AgentIDLengthInBytes (1 byte)
+- `a7` = AgentID (1 byte, 0xa7 = 167)
 
 ### Verification Methods
 
@@ -55,59 +77,44 @@ This ENSIP defines two verification flows:
 When starting from an AI agent registry:
 
 1. The client MUST query the ENS name of the agent using the agent metadata
-2. The client MUST construct the ERC-7930 based chain ID format (with address length 0) for the chain
-3. The client MUST forward resolve the ENS text record `agent-registry:<ERC-7930 based chain ID>` for the specified ENS name
-4. The client MUST verify that the CAIP-350 address corresponds to the expected registry
-5. The client MUST verify that the AgentID corresponds to the expected agent in the registry
+2. The client MUST resolve the ENSIP-24 `data()` record(s) for the specified ENS name using the keys `agent-registry` and `agent-registry: N` in ascending `N` order, where the client chooses how high to check. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). The client MAY stop checking additional keys once the expected registry is found.
+3. For each record, the client MUST decode the ERC-7930 address and AgentID from the returned bytes
+4. The client MUST verify that the decoded ERC-7930 address corresponds to the expected registry (including chain)
+5. The client MUST verify that the decoded AgentID corresponds to the expected agent in the registry
 
 #### ENS-to-Registry Verification
 
 When starting from an ENS name:
 
-1. The client MUST query the `agent-registry:<ERC-7930 base chain ID>` text record for the ENS name
-2. The client MUST verify that the registry contract is the expected AI agent registry
-3. The client MUST verify that the AgentID corresponds to the expected agent in the registry
-4. The client MUST verify that the registry's claimed ENS name from the metadata of the agent matches the original ENS name
+1. The client MUST query the ENSIP-24 `data()` record(s) for the ENS name using the keys `agent-registry` and `agent-registry: N` (where `N` = 1, 2, 3, 4) in ascending `N` order to discover the registries the ENS name is registered with. Clients MAY check additional keys beyond `agent-registry: 4`, but MUST check at least these 5 keys (`agent-registry` through `agent-registry: 4`). An ENS name may have multiple registries, and a client MAY choose to verify one or more depending on context. For example, if a client wants to verify whether an ENS name is registered as an agent on a particular chain, it may resolve the list of registries to discover whether the agent is registered on a registry of that chain. The client MAY stop checking additional keys after finding a registry that matches its criteria.
+2. For each record, the client MUST decode the ERC-7930 address and AgentID from the returned bytes
+3. The client MUST verify that the decoded registry corresponds to an expected AI agent registry for the target chain (if applicable)
+4. The client MUST verify that the decoded AgentID corresponds to the expected agent ID in the registry
+5. The client MUST verify that the registry's claimed ENS name from the metadata of the agent matches the original ENS name
 
 ### Registry Standards
 
-Registries implementing this ENSIP SHOULD follow established standards such as ERC-8004 for AI agent registry implementations. The specific registry standard used MUST be documented and accessible to clients for proper verification.
-
-## Examples
-
-### Example Agent Registry Record
-
-For an AI agent registry on Ethereum Mainnet (EIP-155 chain ID 1) with:
-- ERC-7930 based chain ID (for key): `0x000100000100` (Ethereum Mainnet with no address, see [ERC-7930 Example 4](https://eips.ethereum.org/EIPS/eip-7930))
-- CAIP-350 Address (for value): `0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359` (see [CAIP-350](https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip350.md))
-- Agent ID: `a7` (variable length, 1 byte, 0xa7 = 167)
-
-The text record key would be: `agent-registry:000100000100`
-
-The text record value would be:
-```
-0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35901a7
-```
+This ENSIP is intended to be used for registries that use numeric IDs such as ERC-8004, and allow for saving an ENS name per ID as onchain or offchain metadata. The specific registry standard used MUST be documented and accessible to clients for proper verification.
 
 ### Example Multichain Agent
 
-An ENS name can reference multiple agent registries across different chains using [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) chain ID format:
+An ENS name can reference multiple agent registries (including multiple registries on the same chain) using prioritized keys:
 
-- `agent-registry:000100000100` → Ethereum Mainnet (EIP-155 chain ID 1) registry
-- `agent-registry:00010000018900` → Polygon (EIP-155 chain ID 137) registry
-- `agent-registry:00010002a86a00` → Avalanche (EIP-155 chain ID 43114) registry
-- `agent-registry:000100022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef00` → Solana Mainnet registry
+- `agent-registry` → primary registry entry (any chain; chain is encoded in the ERC-7930 address bytes in the value)
+- `agent-registry: 1` → secondary registry entry
+- `agent-registry: 2` → tertiary registry entry
+- `agent-registry: 3` → etc.
 
 
-Each record contains the CAIP-350 address of the registry on that specific chain along with the agentID.
+Each record contains the ERC-7930 address of the registry (including chain and address) along with the agentID.
 
 ## Rationale
 
-This ENSIP provides a standardized method for AI agent registry verification using the established ERC-7930 bytes format for chain IDs. The design prioritizes simplicity and interoperability by using text records with variable-length agent ID encoding, enabling bidirectional verification between registries and ENS names while maintaining compatibility with existing ENS infrastructure. By including the chain specification in the record key using ERC-7930 based chain ID format, a single ENS name can reference multiple agent registries across different chains, enabling multichain agent implementations. This allows ENS names as agents to operate across multiple blockchain networks while maintaining a single ENS identity.
+This ENSIP provides a standardized method for AI agent registry verification using the established ERC-7930 bytes format for chain-aware addresses and ENSIP-24 `data()` records. The design prioritizes simplicity and interoperability by using a small set of predictable keys with a defined priority order. Because each record value encodes the full ERC-7930 address (including chain), a single ENS name can reference registries across multiple chains, and can also include multiple registries on the same chain.
 
 ## Backwards Compatibility
 
-This ENSIP introduces a new text record key type and does not affect existing ENS functionality. It is fully backward compatible with all existing ENS records and resolvers. Existing ENS names without agent registry text records will continue to function normally.
+No issues. 
 
 ## Security Considerations
 
@@ -116,3 +123,8 @@ None.
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## References
+
+* ENSIP-24: Arbitrary Data Resolution
+* TOON: https://github.com/toon-format/toon

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -95,7 +95,7 @@ An ENS name can reference multiple agent registries across different chains usin
 
 - `agent-registry:000100000100` → Ethereum Mainnet (EIP-155 chain ID 1) registry
 - `agent-registry:00010000018900` → Polygon (EIP-155 chain ID 137) registry
-- `agent-registry:00010002A86A00` → Avalanche (EIP-155 chain ID 43114) registry
+- `agent-registry:00010002a86a00` → Avalanche (EIP-155 chain ID 43114) registry
 - `agent-registry:000100022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef00` → Solana Mainnet registry
 
 

--- a/ensips/25.md
+++ b/ensips/25.md
@@ -11,7 +11,7 @@ ensip:
 
 ## Abstract
 
-This ENSIP defines a standardized method for verifying ENS names associated with AI Agent registries using text records with the format "agent-registry:<ERC-7930 based chain IDs>". The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
+This ENSIP defines a standardized method for verifying ENS names associated with AI Agent registries using text records with the format `agent-registry:<ERC-7930 based chain IDs>`. The specification enables bidirectional verification between an AI agent registry and its corresponding ENS name, ensuring consistency and trust in the AI agent ecosystem. This format enables multichain agents, allowing a single ENS name to reference agent registries across multiple chains.
 
 ## Motivation
 
@@ -56,7 +56,7 @@ When starting from an AI agent registry:
 
 1. The client MUST query the ENS name of the agent using the agent metadata
 2. The client MUST construct the ERC-7930 based chain ID format (with address length 0) for the chain
-3. The client MUST forward resolve the ENS text record `agent-registry:<ERC-7930 Chain ID>` for the specified ENS name
+3. The client MUST forward resolve the ENS text record `agent-registry:<ERC-7930 based chain ID>` for the specified ENS name
 4. The client MUST verify that the CAIP-350 address corresponds to the expected registry
 5. The client MUST verify that the AgentID corresponds to the expected agent in the registry
 


### PR DESCRIPTION
## Summary

This PR adds ENSIP-25, which defines a standardized method for verifying ENS names associated with AI agent registries using text records. The specification enables bidirectional verification between AI agent registries and their corresponding ENS names, and provides a direct lookup method for efficient verification without iteration.

## Key Features

- **Text records with ERC-8127 format**: Uses human-readable text records with the ERC-8127 Token Identifier format (`<agentId>@<registry>`)
- **Prioritized keys**: Supports `agent-registry` and `agent-registry: N` (where N = 1, 2, 3, ...) for multiple registry entries with explicit priority order
- **Direct verification**: Adds `verify-agent-registry: <agentId>@<registry>` parameterized key for direct lookup without iterating over lists
- **ERC-7930 addresses**: Encodes registry addresses using ERC-7930 interoperable address format (chain + address)
- **Multi-registry support**: Allows an agent to be registered in multiple registries across different chains

## Specification Details

- **Record keys**: `agent-registry` (highest priority) and `agent-registry: N` using ERC-8119 format for structured keys
- **Record values**: ERC-8127 Token Identifier format: `<agentId>@<registry>` (e.g., `167@0x00010000010114...`)
- **Direct verification key**: `verify-agent-registry: <agentId>@<registry>` with any non-empty value
- **Verification flows**:
  - Registry-to-ENS: Verify agent's claimed ENS name (via list or direct lookup)
  - ENS-to-Registry: Discover and verify agent IDs associated with an ENS name

## References

- ERC-7930: Interoperable Addresses
- ERC-8119: Parameterized Storage Keys
- ERC-8127: Human Readable Token Identifiers
- ERC-8004: AI Agent Registry standard