### PR TITLE
Add ENSIP-27: Interoperable Names

### DIFF
--- a/ensips/27.md
+++ b/ensips/27.md
@@ -1,0 +1,71 @@
+---
+description: Defines the ENS name @ chain label format for Interoperable Names (implementation of ERC-7828).
+contributors:
+  - nxt3d
+ensip:
+  created: '2026-02-23'
+  status: draft
+---
+
+# ENSIP-27: Interoperable Names
+
+Defines the format for expressing an ENS name on a specific chain using a human-readable chain label.
+
+## Abstract
+
+This ENSIP specifies the format `<name>@<label>`, where `<name>` is an ENS name and `<label>` is a human-readable chain identifier from the `on.eth` ENS namespace. For example, `ens.eth@ethereum` denotes the ENS name `ens.eth` on Ethereum.
+
+## Motivation
+
+An ENS name alone does not indicate which chain an address resolves to. With hundreds of L2s sharing the same address format, this ambiguity can result in funds being sent to the wrong chain. The `<name>@<label>` format provides a human-readable way to specify both the ENS name and the target chain.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Format
+
+```
+<interoperable-name>  ::= <name> "@" <label>
+<name>                ::= [.-:_%a-zA-Z0-9]+
+<label>               ::= [.-:_a-zA-Z0-9]+
+```
+
+- `<name>` is an ENS name (e.g. `ens.eth`, `wallet.ensdao.eth`).
+- `<label>` is a human-readable chain label registered as a subdomain of `on.eth` (e.g. `base`, `ethereum`, `optimism`).
+
+### Resolving the label to chain identifier
+
+The `<label>` maps to a chain identifier via the `on.eth` ENS namespace. To resolve a label:
+
+1. Construct the domain `<label>.on.eth` (e.g. `ethereum.on.eth`).
+2. Resolve the `interoperable-address` data record for that domain using the resolver interface defined in ENSIP-24.
+3. The resolver returns the ERC-7930 Interoperable Address for that chain, which encodes the chain identifier.
+
+The resolver for `on.eth` MUST implement ENSIP-24 (Arbitrary Data Resolution) and support the `interoperable-address` data key.
+
+For Ethereum mainnet, resolving the `interoperable-address` record for `ethereum.on.eth` returns the [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) Interoperable Address `0x00010000010100` (Version 1, ChainType 0x0000, ChainReference 1, no address).
+
+### Examples
+
+| Interoperable Name | Description |
+| ----------------- | ----------- |
+| `ens.eth@base` | ENS name `ens.eth` on Base |
+| `wallet.ensdao.eth@ethereum` | ENS name `wallet.ensdao.eth` on Ethereum mainnet |
+| `alice.eth@optimism` | ENS name `alice.eth` on Optimism |
+
+## Rationale
+
+The `on.eth` namespace provides an onchain registry for chain metadata, enabling chain operators to own their identity data. This specification focuses solely on the ENS format; resolution mechanics are defined in ERC-7828.
+
+## Backwards Compatibility
+
+This specification defines a new format and does not modify existing ENS resolution behavior.
+
+## Security Considerations
+
+Implementers MUST apply ENS name normalization per ENSIP-1 and ENSIP-15 to mitigate homoglyph and spoofing attacks.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -52,7 +52,7 @@ For Ethereum mainnet, resolving the `interoperable-address` record for `ethereum
 | ----------------- | ----------- |
 | `ens.eth@base` | ENS name `ens.eth` on Base |
 | `wallet.ensdao.eth@ethereum` | ENS name `wallet.ensdao.eth` on Ethereum mainnet |
-| `alice.eth@optimism` | ENS name `alice.eth` on Optimism |
+| `alice.eth@optimism` | ENS name `alice.eth` on Optimism Mainnet |
 
 ## Rationale
 


### PR DESCRIPTION
## Description

This PR adds ENSIP-27, which defines the ENS format for Interoperable Names from [ERC-7828](https://eips.ethereum.org/EIPS/eip-7828).

### Format

`<name>@<label>` — e.g. `ens.eth@ethereum`, `ens.eth@base`

- **`<name>`**: ENS name
- **`<label>`**: Human-readable chain label from the `on.eth` namespace

### Resolution

Chain labels resolve to ERC-7930 Interoperable Addresses via ENSIP-24: the `interoperable-address` data record on `<label>.on.eth` (e.g. `ethereum.on.eth` → `0x00010000010100`).

### Rationale

ENS names alone do not indicate which chain an address resolves to. With many L2s using the same address format, this can lead to funds being sent to the wrong chain. The `<name>@<label>` format provides a clear way to specify both the ENS name and the target chain.