### PR TITLE
ENSIP-26: Agent Identity Records for Autonomous Agent Discovery

### DIFF
--- a/ensips/26.md
+++ b/ensips/26.md
@@ -1,0 +1,363 @@
+---
+description: Standardised text-record keys for autonomous agent identity (agent_id, endpoint, pubkey_ed25519, policy_hash, audit_root, capability, reputation_score) so any ENS-aware client reads agent metadata with zero bespoke decoders.
+contributors:
+  - sbo3lagent.eth
+ensip:
+  created: "2026-05-03"
+  status: draft
+---
+
+# ENSIP-26: Agent Identity Records for Autonomous Agent Discovery
+
+## Abstract
+
+This ENSIP defines a small set of standardised text-record keys for
+publishing **autonomous agent identity** on ENS. Seven keys cover
+the load-bearing pieces of the identity surface — agent id,
+endpoint, public key, policy hash, audit root, capabilities,
+reputation. Each key has a normative format and a normative
+interpretation. The goal is one shared convention so 14+ agent
+frameworks (LangChain, LangGraph, CrewAI, AutoGen, ElizaOS,
+LlamaIndex, Vercel AI, OpenAI Assistants, Anthropic SDKs, etc.)
+can all read the same agent record without bespoke decoders.
+
+The convention is fully opt-in: ENS records are an open namespace,
+and existing names with conflicting keys are unaffected.
+
+The proposal **composes with ENSIP-25** ([AI Agent Registry ENS
+Name Verification](https://docs.ens.domains/ensip/25)) by giving an
+ENS-name-bound representation of agent metadata that an
+ENSIP-25-conformant registry entry can mirror or be mirrored into.
+
+## Motivation
+
+Autonomous agents are converging on a shared coordination problem:
+*how do two agents that have never met before authenticate, attest
+to each other's results, and refuse counterparties that can't
+prove identity?* Existing solutions reduce to **naming** ("here is
+the agent's address") plus **bespoke registries** ("look up the
+agent's metadata on our service"). Both are weak: naming alone
+doesn't carry trust, and bespoke registries silo metadata behind
+custom APIs.
+
+ENS already gives us the namespace and the read primitive
+(`text(node, key)`); the missing piece is the **convention**. A
+working reference implementation — seven canonical text records, a
+CCIP-Read gateway, a cross-agent challenge/response protocol —
+already exists at production-shaped scale (60-agent constellation,
+mainnet apex). This ENSIP generalises the convention so any agent
+framework can interoperate.
+
+A consumer reading agent identity should not need to know which
+platform issued the agent. They should be able to:
+
+```
+text(node, "agent_id")        → stable identifier
+text(node, "endpoint")        → "where do I talk to this agent"
+text(node, "pubkey_ed25519")  → "verify this agent's signed claims"
+text(node, "policy_hash")     → "prove the agent runs the policy it claims"
+text(node, "audit_root")      → "anchor a verifiable audit trail"
+text(node, "capability")      → "what sponsor surfaces this agent acts on"
+text(node, "reputation_score") → "0-100 portable reputation signal"
+```
+
+— and consume each value with off-the-shelf ENS tooling (viem,
+ethers.js, ENS App, raw `cast text`). Today this requires
+platform-specific decoders.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY",
+and "OPTIONAL" in this document are to be interpreted as described
+in RFC 2119 and RFC 8174.
+
+### Required text records
+
+The seven keys below SHOULD all be set on a name claiming to
+represent an autonomous agent. Consumers MAY treat any subset as
+the agent's identity for their purposes; the records are
+independent.
+
+| Key | Type | Value |
+|---|---|---|
+| `agent_id` | UTF-8 string, ≤ 64 chars | Stable identifier surviving resolver / record rotation. Conventionally a hyphenated lowercase slug. |
+| `endpoint` | URL (RFC 3986) | The agent's daemon URL. Schemes `http`/`https` REQUIRED; non-`http(s)` schemes RESERVED. |
+| `pubkey_ed25519` | 64-char lowercase hex (32 bytes), no `0x` prefix | The Ed25519 verifying key whose signatures the agent emits on receipts and on cross-agent challenges. |
+| `policy_hash` | 64-char hex (32 bytes), `0x` prefix optional | JCS+SHA-256 commitment to the agent's active policy snapshot. A consumer reads the snapshot at `policy_url` (sibling record) and recomputes to verify. |
+| `audit_root` | 64-char hex (32 bytes), `0x` prefix optional | Cumulative digest of the agent's audit chain. |
+| `capability` | UTF-8 JSON array of strings | List of sponsor-surface capability tags the agent can act on. Conventional tag space: `x402-purchase`, `uniswap-swap`, `keeperhub-job`, `ipfs-pin`, etc. Open list. |
+| `reputation_score` | ASCII decimal integer 0..=100 | Portable reputation signal. |
+
+### Sibling records (optional)
+
+| Key | Purpose |
+|---|---|
+| `policy_url` | URL to the policy snapshot whose `policy_hash` is committed above. Consumer fetches and verifies. |
+| `proof_uri` | URL to a proof artefact (signed receipt, audit bundle). |
+| `pubkey_ed25519_kid` | Stable key identifier — opaque string the agent ships in receipts so consumers can bind the receipt back to the correct version of `pubkey_ed25519` if rotation is in flight. |
+
+### Validation rules
+
+A consumer reading any of the above records MUST:
+
+1. **Reject malformed values.** Hex fields MUST parse as the
+   declared byte-length; URLs MUST parse per RFC 3986; the JSON
+   array for `capability` MUST be a JSON array of strings. Empty
+   strings mean "not set" (NOT a valid value of zero / empty
+   array).
+2. **Treat absent records as "not set".** Consumer policy decides
+   what an unset record means; the ENSIP refuses to imply a default.
+3. **Verify the cryptographic claim before acting on it.** A
+   consumer that reads `policy_hash` and treats it as proof
+   without fetching `policy_url` and recomputing has no security
+   property. The records are *commitments*; the consumer is
+   responsible for *verification*.
+
+A publisher writing any of the above records MUST:
+
+1. **Compute deterministically.** Same active policy → same
+   `policy_hash`. Same audit chain → same `audit_root`. The
+   records are reproducible from the agent's runtime state;
+   non-determinism here defeats verification.
+2. **Bind across records.** The `pubkey_ed25519` is the verifying
+   key for the receipts pointed at by `proof_uri` and the audit
+   chain hashed into `audit_root`. Cross-record drift (publishing
+   an `audit_root` that doesn't match the chain that produced
+   `proof_uri`) breaks consumer verification with no recovery path
+   short of re-publishing.
+3. **Update atomically where possible.** Use the resolver's
+   `multicall(setText × N)` (ENS PublicResolver supports this) so
+   `audit_root` and `proof_uri` advance in the same transaction.
+   Half-updated record sets are observably wrong.
+
+### CCIP-Read compatibility
+
+The convention is fully compatible with ENSIP-10 / EIP-3668
+CCIP-Read. A name whose resolver is an OffchainResolver MAY serve
+any of the above records via the CCIP-Read gateway flow. The
+reference implementation's deployed Sepolia OffchainResolver
+([`0x87e99508C222c6E419734CACbb6781b8d282b1F6`](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6))
+plus its Vercel-hosted gateway is a working reference; any
+ENSIP-10-aware client (viem, ethers.js, ENS App) handles the
+resolution transparently.
+
+This is the recommended path for high-frequency records:
+`reputation_score` and `audit_root` change faster than per-update
+`setText` is economical; CCIP-Read pushes the cost into gateway
+operation.
+
+### Cross-chain compatibility
+
+The same convention applies on Optimism, Base, Polygon, Arbitrum,
+Linea, and any chain ENS deploys to. Per-chain reputation and
+audit roots MAY differ if the agent operates differently per
+chain; consumers reading multiple chains MAY aggregate via a
+caller-defined algorithm. A reference cross-chain aggregator (with
+weighting by chain prominence + recency) is shipped as part of
+the reference implementation.
+
+## Rationale
+
+### Why namespace at the bare key, not behind a prefix
+
+Two designs were considered:
+
+1. **Bare keys** (`agent_id`, `endpoint`, ...) — this proposal.
+2. **Namespaced keys** (`agent.agent_id`, `agent.endpoint`, ...).
+
+Bare keys win on consumer ergonomics: `viem.getEnsText("agent_id")`
+reads the value with zero special handling. Namespaced keys would
+force every ENS-aware library to extend its API or operate at the
+raw `text(node, key)` level. Conflicts with non-agent uses of the
+same keys are mitigated by the convention being **opt-in**: a name
+that doesn't claim to represent an agent doesn't set these keys.
+
+For platform-specific extensions (e.g. project-specific
+attestation records), prefixing remains the right pattern. This
+ENSIP standardises only the **shared** convention.
+
+### Why text records, not a new resolver method
+
+ENSIP-10's wildcard resolution + Universal Resolver multi-call
+already give cheap batch reads of N text records in one
+`eth_call`. Adding an `agentMetadata(node)` resolver method would
+require every consumer to extend its ABI for a marginal
+gas-efficiency win that the Universal Resolver path already
+captures. Text records compose with existing infrastructure; new
+resolver methods don't.
+
+### Why these seven keys (and not more, not fewer)
+
+Seven covers the load-bearing pieces a production agent fleet
+exercises:
+
+- `agent_id` + `endpoint` + `pubkey_ed25519` — minimum to
+  authenticate an agent.
+- `policy_hash` + `audit_root` — minimum to verify the agent's
+  runtime claims independently.
+- `capability` — minimum for routing decisions ("which agent do I
+  delegate this swap to?").
+- `reputation_score` — minimum for trust-tier policy ("refuse
+  delegation below 60").
+
+Fewer keys leave the trust surface incomplete (`agent_id` alone
+doesn't authenticate). More keys risk standardising premature
+patterns. The seven here are what the reference implementation's
+60-agent fleet actually publishes today; future ENSIPs can add
+records as ecosystem patterns stabilise.
+
+### Relationship with ENSIP-25 and ERC-8004
+
+[ENSIP-25 (AI Agent Registry ENS Name Verification)](https://docs.ens.domains/ensip/25)
+specifies how a name verifies an agent registered in an
+[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)-style
+registry contract. ERC-8004 specifies **the on-chain registry
+contract surface**.
+
+This ENSIP standardises **the names ENS sees** for agent
+metadata. The three efforts compose:
+
+- An ERC-8004 registry MAY mirror its agent metadata into the
+  agent's ENS records (this ENSIP).
+- An ENSIP-26 publisher MAY anchor its agent into an ERC-8004
+  registry for on-chain consumers, and verify that anchoring per
+  ENSIP-25.
+- A consumer MAY read both: ENSIP-26 records for off-chain
+  verification, ENSIP-25 + ERC-8004 for on-chain proof.
+
+They serve different consumer shapes (off-chain reads vs on-chain
+gas-cheap checks) and don't compete.
+
+## Reference Implementation
+
+A complete reference implementation is shipped under permissive
+license at [`B2JK-Industry/SBO3L-ethglobal-openagents-2026`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026):
+
+| Component | Location |
+|---|---|
+| Solidity OffchainResolver (deployed Sepolia) | [`crates/sbo3l-identity/contracts/OffchainResolver.sol`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/contracts/OffchainResolver.sol) |
+| Rust resolver client | [`crates/sbo3l-identity/src/ens_live.rs`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/src/ens_live.rs) |
+| Universal Resolver migration | [`crates/sbo3l-identity/src/universal.rs`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/src/universal.rs) |
+| Cross-agent challenge protocol | [`crates/sbo3l-identity/src/cross_agent.rs`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/src/cross_agent.rs) |
+| 60-agent fleet manifest | [`docs/proof/ens-fleet-agents-60-2026-05-01.json`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/proof/ens-fleet-agents-60-2026-05-01.json) |
+
+### Live verifiable example
+
+The mainnet apex `sbo3lagent.eth` resolves the seven canonical
+records today. Verify with raw `cast`:
+
+```bash
+RESOLVER=0xF29100983E058B709F3D539b0c765937B804AC15
+NODE=$(cast namehash sbo3lagent.eth)
+for KEY in agent_id endpoint pubkey_ed25519 policy_hash audit_root capability reputation_score; do
+  printf '%s = ' "$KEY"
+  cast call "$RESOLVER" "text(bytes32,string)(string)" "$NODE" "$KEY" \
+    --rpc-url https://ethereum-rpc.publicnode.com
+done
+```
+
+A Sepolia subname `research-agent.sbo3lagent.eth` is wired through
+the deployed OffchainResolver and demonstrates the CCIP-Read flow
+end-to-end:
+
+```bash
+viem.getEnsText({
+  name: 'research-agent.sbo3lagent.eth',
+  key:  'agent_id',
+  chain: sepolia,
+})
+// → "research-agent-01"
+```
+
+## Backwards Compatibility
+
+ENS text records are an open namespace. This ENSIP standardises
+seven key names without affecting any other text record. Existing
+records on agent-shaped names that already use one or more of
+these keys are preserved unchanged; consumers MUST validate per
+the rules above and reject malformed values rather than coerce
+them.
+
+A name that doesn't claim to represent an agent doesn't set these
+keys; their absence MUST be treated as "this name is not an
+agent" rather than "this is a malformed agent."
+
+## Test Cases
+
+Canonical example: `sbo3lagent.eth` on mainnet. Records as of
+2026-05-03:
+
+```
+agent_id            = "sbo3lagent"
+endpoint            = "http://apex.sbo3l.dev/v1"
+pubkey_ed25519      = "<32-byte hex>"
+policy_hash         = "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf"
+audit_root          = "0000000000000000000000000000000000000000000000000000000000000000"
+capability          = '["x402-purchase","uniswap-swap","keeperhub-job"]'
+reputation_score    = "100"
+```
+
+### Validation matrix
+
+#### Accepted values
+
+| Field | Value | Reason |
+|---|---|---|
+| `agent_id` | `"research-agent-01"` | Hyphenated slug, ≤ 64 chars |
+| `endpoint` | `"https://example.com:8730/v1"` | Valid HTTPS URL |
+| `pubkey_ed25519` | 64-char lowercase hex | Correct byte length |
+| `policy_hash` | 64-char hex (with or without `0x` prefix) | Correct byte length |
+| `capability` | `'["x402-purchase","uniswap-swap"]'` | JSON array of strings |
+| `reputation_score` | `"87"` | Decimal in 0..=100 |
+
+#### Rejected values
+
+| Field | Value | Reason |
+|---|---|---|
+| `agent_id` | `""` | Empty = "not set", NOT a valid id |
+| `endpoint` | `"example.com:8730/v1"` | Missing scheme |
+| `endpoint` | `"ftp://example.com/agent"` | RESERVED scheme |
+| `pubkey_ed25519` | `"deadbeef"` | Wrong length |
+| `pubkey_ed25519` | `"DEADBEEF…"` (uppercase) | Lowercase REQUIRED |
+| `policy_hash` | `"0x1234"` | Wrong length |
+| `capability` | `"not-json"` | Must be JSON array |
+| `capability` | `'[1, 2, 3]'` | Array MUST contain strings |
+| `reputation_score` | `"-1"` | Out of range |
+| `reputation_score` | `"101"` | Out of range |
+| `reputation_score` | `"87.5"` | Decimal point forbidden |
+| `reputation_score` | `"007"` | Leading zeros forbidden |
+
+## Security Considerations
+
+- **Tampering resistance:** the records are *commitments*, not
+  *proofs*. A consumer that wants tamper-resistant agent
+  attestation MUST also fetch `policy_url` + recompute
+  `policy_hash`, fetch the audit chain referenced by `audit_root`
+  + walk it, and verify receipts under `pubkey_ed25519`. The ENSIP
+  is the wire format; the trust model is the consumer's.
+
+- **Sybil resistance:** anyone can register an ENS name and
+  publish these records. The convention solves "is this the agent
+  that signed this receipt?", not "is this agent a real entity?".
+  For Sybil resistance, layer ERC-8004 reputation registries on top
+  and verify membership via ENSIP-25.
+
+- **Operator-side compromise:** if the wallet that owns the ENS
+  name leaks, the attacker can rotate every record. ENS doesn't
+  prevent that. Mitigations are operator-side (multisig the apex,
+  key-rotate from cold storage, monitor the chain log) — same
+  posture as any high-value wallet.
+
+- **CCIP-Read trust model:** if the agent uses an OffchainResolver
+  to serve dynamic records, the gateway's signing key becomes
+  load-bearing. An attacker who controls the gateway URL but not
+  the gateway signing key cannot forge records (the contract
+  rejects); an attacker who controls the signing key can lie about
+  `capability` + `reputation_score` but cannot rewrite
+  previously-pinned audit roots without invalidating every
+  receipt that referenced them.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

Defines a small set of standardised text-record keys for publishing **autonomous agent identity** on ENS:

```
agent_id, endpoint, pubkey_ed25519, policy_hash,
audit_root, capability, reputation_score
```

Each key has a normative format and a normative interpretation. Goal: one shared convention so every agent framework (LangChain, LangGraph, CrewAI, AutoGen, ElizaOS, LlamaIndex, Vercel AI, OpenAI Assistants, Anthropic SDKs, etc.) reads the same agent record without bespoke decoders. Fully opt-in — names that don't claim to represent an agent are unaffected.

## Why now

Cross-agent coordination is converging on the problem *"two agents that have never met before need to authenticate, attest, and refuse counterparties."* Existing solutions reduce to **naming alone** (no trust signal) or **bespoke registries** (siloed metadata behind custom APIs). ENS already gives us the namespace and the read primitive; the missing piece is the **convention**.

A working reference implementation already exists at production-shaped scale (60-agent constellation, mainnet apex `sbo3lagent.eth` resolving all seven records, deployed Sepolia OffchainResolver demonstrating the CCIP-Read flow end-to-end). The proposal generalises so platforms beyond the reference implementation can interoperate.

## Composition with existing standards

- **ENSIP-25 (AI Agent Registry ENS Name Verification)** — specifies how a name verifies an agent registered in an ERC-8004 registry. ENSIP-26 specifies the metadata the ENS-name-bound representation carries. Compatible by design.
- **ERC-8004 (Identity Registry contracts)** — specifies the on-chain registry surface. ENSIP-26 specifies the off-chain ENS surface. They serve different consumer shapes (off-chain reads vs on-chain gas-cheap checks).

## Reference implementation

[`B2JK-Industry/SBO3L-ethglobal-openagents-2026`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026) — permissive license, 60-agent fleet manifest, deployed Sepolia OffchainResolver at [`0x87e99508…b1f6`](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6), live verifiable mainnet apex.

Verify mainnet apex carrying the records:

```bash
RESOLVER=0xF29100983E058B709F3D539b0c765937B804AC15
NODE=$(cast namehash sbo3lagent.eth)
for KEY in agent_id endpoint pubkey_ed25519 policy_hash audit_root capability reputation_score; do
  printf '%s = ' "$KEY"
  cast call "$RESOLVER" "text(bytes32,string)(string)" "$NODE" "$KEY" \
    --rpc-url https://ethereum-rpc.publicnode.com
done
```

## Discussion

Happy to iterate on any of: key naming, the boundary between this and ENSIP-25, narrower scope (split into per-purpose ENSIPs), or the namespace decision (bare keys vs `agent.*` prefix). The reference implementation's full test suite is committed to maintaining post-merge.

🤖 PR opened by an SBO3L (B2JK-Industry) contributor.