### PR TITLE
Add ENSIP: Agent Card Schema (/.well-known/agent.json)

### DIFF
--- a/ensips/27.md
+++ b/ensips/27.md
@@ -172,7 +172,7 @@ This field is part of the WYRIWE input-provenance commitment
 verification of the transformation applied between raw input and model input. A
 conformance set — a valid pipeline spec, the identity sentinel, and a tampered spec
 that MUST fail verification — is provided as reference vectors so
-independent implementations converge on bytes, not prose. (Vector-set location to be finalized with the editors — `assets/` here or a companion repo.)
+independent implementations converge on bytes, not prose. A reference vector set is published at [ensip27-sanitizationspec-vectors](https://github.com/babyblueviper1/ensip27-sanitizationspec-vectors) — three vectors (`valid_pipeline` passes, `identity_sentinel` passes, `tampered` MUST fail), encoded CIDv1-raw + sha2-256 so each CID is a pure `sha256` of the exact bytes and any party re-derives them with stdlib alone (no IPFS node); CI recomputes all three on every push. To be vendored into `assets/` once the ENSIP number is assigned.
 
 ### The `trustEndpoints` field
 

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -1,5 +1,5 @@
 ---
-description: Standardized schema for the agent card document served at /.well-known/agent.json
+description: Standardized schema for the agent card document served at /.well-known/agent-card.json
 contributors:
   - dinamic.eth
   - babyblueviper1
@@ -14,7 +14,7 @@ track: Ecosystem
 ## Abstract
 
 This ENSIP defines the schema for the agent card document — a JSON resource served at
-`/.well-known/agent.json` — that describes an AI agent's capabilities, MCP endpoint,
+`/.well-known/agent-card.json` — that describes an AI agent's capabilities, MCP endpoint,
 authentication requirements, on-chain identity, input provenance configuration, and
 optional pointers for independently verifying the agent's output.
 ENSIP-26 defines how to discover an agent card via ENS text records;
@@ -34,7 +34,7 @@ served there completes the discovery chain:
 ```
 ENS name
   → agent-endpoint[mcp] text record   (ENSIP-26)
-  → /.well-known/agent.json            (this ENSIP)
+  → /.well-known/agent-card.json       (this ENSIP)
   → mcp endpoint + capabilities + identity + verifiable provenance
 ```
 
@@ -45,11 +45,20 @@ ENS name
 An agent card MUST be served at:
 
 ```
-{base-url}/.well-known/agent.json
+{base-url}/.well-known/agent-card.json
 ```
 
 where `base-url` is the value of the `agent-endpoint[mcp]` or `agent-endpoint[a2a]`
-text record, or the root of any agent gateway domain.
+text record, or the root of any agent gateway domain. This is the canonical path
+registered by [A2A v0.3.0](https://a2a-protocol.org/v0.3.0/specification/) (the path
+moved from `/.well-known/agent.json` to `/.well-known/agent-card.json` following IANA
+feedback); reusing it keeps ENSIP-27 cards co-located and discoverable by A2A clients.
+
+A gateway MAY additionally serve the card at the legacy path
+`{base-url}/.well-known/agent.json` (A2A ≤ v0.2.x) as a compatibility alias. When it
+does, `agent.json` is a legacy alias only — `agent-card.json` is the canonical resource,
+and both paths MUST return a byte-identical document. Clients SHOULD request
+`agent-card.json` first and MAY fall back to `agent.json`.
 
 The resource MUST be served over HTTPS and MUST return `Content-Type: application/json`.
 
@@ -87,10 +96,10 @@ The resource MUST be served over HTTPS and MUST return `Content-Type: applicatio
 
 ### Document discrimination (A2A interoperability)
 
-`/.well-known/agent.json` is also the serving path for [A2A protocol agent
-cards](https://a2a-protocol.org/schemas/agent-card/v0.3.json), whose schema is
-byte-compatible with the required fields above — reuse of the path is deliberate and
-maximises interop. Two fields, however, carry ENSIP-27-specific semantics, and a client
+`/.well-known/agent-card.json` is also the canonical serving path for [A2A protocol agent
+cards](https://a2a-protocol.org/v0.3.0/specification/) as of v0.3.0 (the earlier
+`/.well-known/agent.json` is A2A ≤ v0.2.x), whose schema is byte-compatible with the
+required fields above — reuse of the path is deliberate and maximises interop. Two fields, however, carry ENSIP-27-specific semantics, and a client
 MUST NOT act on them without first confirming which document class it holds:
 
 - **`schema_version` is the ENSIP-27 discriminator.** A document carrying
@@ -132,7 +141,8 @@ explicitly, so a client never has to guess the protocol behind a bare `url`:
 
 One card, many transports, no key collision — MCP and A2A both first-class. (Prior art:
 a live one-card-many-transports example is served at
-`https://api.babyblueviper.com/.well-known/agent.json`.)
+`https://api.babyblueviper.com/.well-known/agent-card.json`, with
+`/.well-known/agent.json` kept as a v0.2.x compatibility alias.)
 
 ### The `erc8004` identity field
 
@@ -255,13 +265,16 @@ chain terminate at something recomputable rather than asserted. (Prior art: a li
 }
 ```
 
-Live: `GET https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d/5/.well-known/agent.json`
+Live: `GET https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d/5/.well-known/agent-card.json`
 
 ## Rationale
 
-**Why `/.well-known/agent.json` and not a custom path?**
-RFC 8615 reserves `/.well-known/` for service metadata. This is already the convention
-used by multiple agent frameworks independently. Standardising on it avoids fragmentation.
+**Why `/.well-known/agent-card.json` and not a custom path?**
+RFC 8615 reserves `/.well-known/` for service metadata, and `agent-card.json` is A2A's
+canonical card path as of v0.3.0 (moved from `agent.json` following IANA feedback).
+Co-locating on it maximises interop and avoids fragmentation; the legacy `agent.json`
+path is retained only as an optional byte-identical compatibility alias for A2A ≤ v0.2.x
+clients, never as the canonical location.
 
 **Why discriminate from A2A rather than fork the path?**
 Sharing the path with A2A maximises interop — the required fields are byte-compatible by
@@ -299,8 +312,11 @@ and [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) (Well-Known URIs).
 ## Backwards Compatibility
 
 Clients unaware of this ENSIP will receive the agent card as an unstructured JSON
-blob. Unknown fields are ignored. Existing gateways serving `/.well-known/agent.json`
-with a subset of the required fields will continue to function — clients SHOULD treat
+blob. Unknown fields are ignored. Gateways that serve the card only at the legacy
+`/.well-known/agent.json` path (A2A ≤ v0.2.x) SHOULD add `/.well-known/agent-card.json`
+as the canonical location while keeping `agent.json` as a byte-identical alias; clients
+SHOULD request `agent-card.json` first and fall back to `agent.json`. Existing gateways
+serving a subset of the required fields will continue to function — clients SHOULD treat
 missing optional fields as absent rather than erroring. A2A clients that do not
 recognise `schema_version` will still parse the byte-compatible required fields; the
 discrimination rule exists to protect clients that act on `url`.

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -2,6 +2,7 @@
 description: Standardized schema for the agent card document served at /.well-known/agent.json
 contributors:
   - dinamic.eth
+  - babyblueviper1
 ensip:
   created: '2026-05-19'
   status: draft
@@ -14,7 +15,8 @@ track: Ecosystem
 
 This ENSIP defines the schema for the agent card document — a JSON resource served at
 `/.well-known/agent.json` — that describes an AI agent's capabilities, MCP endpoint,
-authentication requirements, on-chain identity, and input provenance configuration.
+authentication requirements, on-chain identity, input provenance configuration, and
+optional pointers for independently verifying the agent's output.
 ENSIP-26 defines how to discover an agent card via ENS text records;
 this ENSIP defines what the card contains.
 
@@ -33,7 +35,7 @@ served there completes the discovery chain:
 ENS name
   → agent-endpoint[mcp] text record   (ENSIP-26)
   → /.well-known/agent.json            (this ENSIP)
-  → mcp endpoint + capabilities + identity
+  → mcp endpoint + capabilities + identity + verifiable provenance
 ```
 
 ## Specification
@@ -83,6 +85,27 @@ The resource MUST be served over HTTPS and MUST return `Content-Type: applicatio
 }
 ```
 
+### Document discrimination (A2A interoperability)
+
+`/.well-known/agent.json` is also the serving path for [A2A protocol agent
+cards](https://a2a-protocol.org/schemas/agent-card/v0.3.json), whose schema is
+byte-compatible with the required fields above — reuse of the path is deliberate and
+maximises interop. Two fields, however, carry ENSIP-27-specific semantics, and a client
+MUST NOT act on them without first confirming which document class it holds:
+
+- **`schema_version` is the ENSIP-27 discriminator.** A document carrying
+  `protocolVersion` (and no `schema_version`) is an A2A agent card, not an ENSIP-27
+  card. A conforming client MUST check `schema_version` before reading `url`.
+- **In this schema, top-level `url` is the agent's MCP endpoint.** In A2A the same key
+  is the JSON-RPC endpoint — same key, same type, different transport. A conforming
+  client MUST NOT infer the transport from the key alone.
+
+The failure mode this rule prevents is the silent one: the document parses, the client
+speaks the wrong protocol to the endpoint, and the error surfaces two layers from its
+cause. Agents exposing more than one transport SHOULD additionally populate the optional
+`supported_interfaces` array (below), which names each transport explicitly and removes
+the key collision entirely.
+
 ### Optional fields
 
 | Field | Type | Description |
@@ -90,8 +113,26 @@ The resource MUST be served over HTTPS and MUST return `Content-Type: applicatio
 | `description` | string | Human-readable agent description |
 | `inputSources` | string[] | Declared input origin scope (e.g. `["user", "system"]`) |
 | `trustScope` | object | A2A trust config — `{ transitive: bool, maxDepth: int, capabilities: string[] }` |
-| `sanitizationSpec` | string | IPFS URI of the input sanitization pipeline spec |
+| `supported_interfaces` | object[] | Explicit multi-transport list — `[{ protocol: "mcp"\|"a2a"\|"rest", url, protocol_version }]`. When present, disambiguates transports without relying on the top-level `url`. |
+| `sanitizationSpec` | string | IPFS URI of the input sanitization pipeline spec (WYRIWE input-provenance commitment) |
 | `erc8004` | object | On-chain agent identity anchor — `{ registry: address, agentId: string }` |
+| `trustEndpoints` | object | Pointers for independently verifying the agent's *output* — `{ verifyProof: url, independentNodes: url[], selfHostVerifier: string }` |
+
+### The `supported_interfaces` field
+
+When an agent exposes more than one transport, `supported_interfaces` carries each one
+explicitly, so a client never has to guess the protocol behind a bare `url`:
+
+```json
+"supported_interfaces": [
+  { "protocol": "mcp", "url": "https://gateway.example/agent/…/mcp", "protocol_version": "2025-06-18" },
+  { "protocol": "a2a", "url": "https://gateway.example/agent/…/a2a", "protocol_version": "0.3" }
+]
+```
+
+One card, many transports, no key collision — MCP and A2A both first-class. (Prior art:
+a live one-card-many-transports example is served at
+`https://api.babyblueviper.com/.well-known/agent.json`.)
 
 ### The `erc8004` identity field
 
@@ -122,10 +163,43 @@ the verification layer (ENSIP-25), and the on-chain identity layer (ERC-8004).
 `sanitizationSpec` is an IPFS URI pointing to the specification of the input
 sanitization pipeline applied before the model receives the input. When the
 identity sentinel is used (no sanitization), the value MUST be the URI of the
-identity sentinel specification.
+identity sentinel specification — **absence is not equivalent to the sentinel**. Absence
+claims nothing; the identity sentinel claims, verifiably, that no transformation was
+applied. That asymmetry is what makes the commitment checkable rather than assumed.
 
-This field is part of the WYRIWE input provenance commitment and enables independent
-verification of the transformation applied between raw input and model input.
+This field is part of the WYRIWE input-provenance commitment
+([ERC-8299](https://github.com/ethereum/ERCs/pull/1810)) and enables independent
+verification of the transformation applied between raw input and model input. A
+conformance set — a valid pipeline spec, the identity sentinel, and a tampered spec
+that MUST fail verification — is provided as reference vectors (see Conformance) so
+independent implementations converge on bytes, not prose.
+
+### The `trustEndpoints` field
+
+Where `erc8004` anchors *who* the agent is and `sanitizationSpec` commits *what went
+in*, `trustEndpoints` lets a client independently check *what comes out* — without
+trusting the gateway or the agent:
+
+```json
+"trustEndpoints": {
+  "verifyProof":      "https://gateway.ensub.org/agent/{registry}/{agentId}/verify",
+  "independentNodes": ["https://gateway.gen-plasma.com", "https://ccip-router-production.up.railway.app"],
+  "selfHostVerifier": "npm:ccip-router"
+}
+```
+
+- **`verifyProof`** — an endpoint returning a signed, recomputable proof for a given
+  output or `inputHash` (e.g. a WYRIWE commitment), checkable offline against the
+  agent's published key with no further call to the gateway.
+- **`independentNodes`** — peer nodes that re-derive the same verdict from their *own*
+  reads (non-self-attested), so a claim can be confirmed against a node the agent does
+  not control.
+- **`selfHostVerifier`** — a package a client can run to recompute the proofs itself,
+  trusting no endpoint at all.
+
+The field is optional and zero-cost when absent; when present it makes the discovery
+chain terminate at something recomputable rather than asserted. (Prior art: a live
+`trustEndpoints`-equivalent block has been served since June 2026 at the URL above.)
 
 ### Full example
 
@@ -151,6 +225,9 @@ verification of the transformation applied between raw input and model input.
   "defaultInputModes":  ["text/plain"],
   "defaultOutputModes": ["text/plain"],
   "inputSources":    ["user", "system"],
+  "supported_interfaces": [
+    { "protocol": "mcp", "url": "https://gateway.ensub.org/agent/0xe61f.../5/mcp", "protocol_version": "2025-06-18" }
+  ],
   "trustScope": {
     "transitive": false,
     "maxDepth":   0,
@@ -160,6 +237,11 @@ verification of the transformation applied between raw input and model input.
   "erc8004": {
     "registry": "0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d",
     "agentId":  "5"
+  },
+  "trustEndpoints": {
+    "verifyProof":      "https://gateway.ensub.org/agent/verify",
+    "independentNodes": ["https://gateway.gen-plasma.com"],
+    "selfHostVerifier": "npm:ccip-router"
   },
   "skills": [
     {
@@ -181,6 +263,12 @@ Live: `GET https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d
 RFC 8615 reserves `/.well-known/` for service metadata. This is already the convention
 used by multiple agent frameworks independently. Standardising on it avoids fragmentation.
 
+**Why discriminate from A2A rather than fork the path?**
+Sharing the path with A2A maximises interop — the required fields are byte-compatible by
+design. The cost is a key collision on `url`; the `schema_version` discriminator rule
+(and the optional `supported_interfaces` array) resolves it so both document classes
+coexist on the same path without silent protocol mismatch.
+
 **Why a separate ENSIP from ENSIP-26?**
 ENSIP-26 explicitly defers schema standardisation to future ENSIPs. This ENSIP is
 that future — it adds schema without changing the discovery mechanism.
@@ -190,6 +278,13 @@ Not every agent will have an on-chain ERC-8004 identity. The field is optional t
 allow offchain-only agents to conform to the schema. When present it SHOULD be treated
 as the authoritative identity anchor.
 
+**Why an optional `trustEndpoints` pointer?**
+`erc8004` and `sanitizationSpec` let a client check who the agent is and what it
+received. `trustEndpoints` extends the same recompute-don't-trust discipline to the
+agent's *output*, so the discovery chain terminates at something a third party can
+verify independently rather than at the gateway's word — without imposing any cost on
+agents that don't offer it.
+
 **Relationship to ENSIP-25**
 [ENSIP-25](https://github.com/ensdomains/ensips/blob/main/ensips/25.md) defines how to verify an ENS name's association with an agent registry entry.
 The `erc8004` field in the agent card is the discovery complement — it tells a client
@@ -198,6 +293,7 @@ where to find the on-chain identity to verify against.
 This ENSIP completes the stack alongside [ENSIP-26](https://github.com/ensdomains/ensips/blob/main/ensips/26.md) (discovery layer),
 [ERC-8004](https://ethereum-magicians.org/t/erc-8004-agent-nft-identity-registry) (on-chain identity registry),
 [ERC-8217](https://ethereum-magicians.org/t/add-erc-8217-agent-nft-identity-bindings/28339) (agent NFT identity bindings),
+[ERC-8299](https://github.com/ethereum/ERCs/pull/1810) (WYRIWE input provenance),
 and [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) (Well-Known URIs).
 
 ## Backwards Compatibility
@@ -205,7 +301,9 @@ and [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) (Well-Known URIs).
 Clients unaware of this ENSIP will receive the agent card as an unstructured JSON
 blob. Unknown fields are ignored. Existing gateways serving `/.well-known/agent.json`
 with a subset of the required fields will continue to function — clients SHOULD treat
-missing optional fields as absent rather than erroring.
+missing optional fields as absent rather than erroring. A2A clients that do not
+recognise `schema_version` will still parse the byte-compatible required fields; the
+discrimination rule exists to protect clients that act on `url`.
 
 ## Security Considerations
 
@@ -218,6 +316,22 @@ agent cards served over plain HTTP.
 **`sanitizationSpec` verification**: Clients that verify input provenance MUST fetch
 the spec at the declared IPFS URI and independently compute the pipeline hash rather
 than trusting the gateway's attestation.
+
+**`trustEndpoints` are pointers, not proofs**: A client MUST verify the proofs returned
+by these endpoints — check the signature, recompute the commitment — rather than
+trusting the endpoint's response. `independentNodes` exist precisely so a verdict can be
+confirmed against a node the agent does not control; a client SHOULD confirm agreement
+across at least one independent node before acting on a high-value claim.
+
+**Protocol confusion**: A client MUST determine document class via `schema_version`
+before dereferencing `url`, to avoid speaking MCP to an A2A endpoint or vice versa.
+
+## Conformance
+
+Reference vectors for the `sanitizationSpec` "clients MUST fetch and verify" path — a
+valid pipeline spec, the identity sentinel, and a tampered pipeline spec that MUST fail
+verification — are provided so independent implementations converge on identical bytes.
+[Conformance vectors location TBD — assets/ or companion repo.]
 
 ## Copyright
 

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -171,8 +171,8 @@ This field is part of the WYRIWE input-provenance commitment
 ([ERC-8299](https://github.com/ethereum/ERCs/pull/1810)) and enables independent
 verification of the transformation applied between raw input and model input. A
 conformance set — a valid pipeline spec, the identity sentinel, and a tampered spec
-that MUST fail verification — is provided as reference vectors (see Conformance) so
-independent implementations converge on bytes, not prose.
+that MUST fail verification — is provided as reference vectors so
+independent implementations converge on bytes, not prose. (Vector-set location to be finalized with the editors — `assets/` here or a companion repo.)
 
 ### The `trustEndpoints` field
 
@@ -325,13 +325,6 @@ across at least one independent node before acting on a high-value claim.
 
 **Protocol confusion**: A client MUST determine document class via `schema_version`
 before dereferencing `url`, to avoid speaking MCP to an A2A endpoint or vice versa.
-
-## Conformance
-
-Reference vectors for the `sanitizationSpec` "clients MUST fetch and verify" path — a
-valid pipeline spec, the identity sentinel, and a tampered pipeline spec that MUST fail
-verification — are provided so independent implementations converge on identical bytes.
-[Conformance vectors location TBD — assets/ or companion repo.]
 
 ## Copyright
 

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -1,0 +1,228 @@
+---
+description: Standardized schema for the agent card document served at /.well-known/agent.json
+contributors:
+  - dinamic.eth
+ensip:
+  created: '2026-05-19'
+  status: draft
+track: Ecosystem
+---
+
+# ENSIP-27: Agent Card Schema
+
+## Abstract
+
+This ENSIP defines the schema for the agent card document — a JSON resource served at
+`/.well-known/agent.json` — that describes an AI agent's capabilities, MCP endpoint,
+authentication requirements, on-chain identity, and input provenance configuration.
+ENSIP-26 defines how to discover an agent card via ENS text records;
+this ENSIP defines what the card contains.
+
+## Motivation
+
+ENSIP-26 standardises `agent-endpoint[mcp]` and `agent-endpoint[a2a]` as text record
+keys for agent discovery. It intentionally leaves the format of the agent card document
+open for future standardisation. Without a shared schema, every gateway invents its own
+format and clients cannot parse agent cards interoperably.
+
+The `/.well-known/` path convention (RFC 8615) is already used by multiple agent
+frameworks as the natural location for service metadata. Standardising the document
+served there completes the discovery chain:
+
+```
+ENS name
+  → agent-endpoint[mcp] text record   (ENSIP-26)
+  → /.well-known/agent.json            (this ENSIP)
+  → mcp endpoint + capabilities + identity
+```
+
+## Specification
+
+### Discovery path
+
+An agent card MUST be served at:
+
+```
+{base-url}/.well-known/agent.json
+```
+
+where `base-url` is the value of the `agent-endpoint[mcp]` or `agent-endpoint[a2a]`
+text record, or the root of any agent gateway domain.
+
+The resource MUST be served over HTTPS and MUST return `Content-Type: application/json`.
+
+### Required fields
+
+```json
+{
+  "schema_version": "0.0.1",
+  "name":           "string — human-readable agent name",
+  "url":            "string — fully-qualified MCP endpoint URL",
+  "provider": {
+    "organization": "string",
+    "url":          "string"
+  },
+  "version":     "string — semver",
+  "capabilities": {
+    "streaming":              "boolean",
+    "pushNotifications":      "boolean",
+    "stateTransitionHistory": "boolean"
+  },
+  "authentication": {
+    "schemes": ["Bearer"]
+  },
+  "skills": [
+    {
+      "id":          "string",
+      "name":        "string",
+      "description": "string",
+      "tags":        ["string"],
+      "examples":    ["string"]
+    }
+  ]
+}
+```
+
+### Optional fields
+
+| Field | Type | Description |
+|---|---|---|
+| `description` | string | Human-readable agent description |
+| `inputSources` | string[] | Declared input origin scope (e.g. `["user", "system"]`) |
+| `trustScope` | object | A2A trust config — `{ transitive: bool, maxDepth: int, capabilities: string[] }` |
+| `sanitizationSpec` | string | IPFS URI of the input sanitization pipeline spec |
+| `erc8004` | object | On-chain agent identity anchor — `{ registry: address, agentId: string }` |
+
+### The `erc8004` identity field
+
+When present, `erc8004` links the agent card to a verifiable on-chain identity
+registered in an ERC-8004 agent identity registry:
+
+```json
+"erc8004": {
+  "registry": "0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d",
+  "agentId":  "5"
+}
+```
+
+Verifiers SHOULD use this field to confirm the agent's existence and ownership
+without trusting the gateway:
+
+```solidity
+registry.ownerOf(agentId)        // confirms agent exists
+registry.getAgentWallet(agentId) // hot wallet for A2A signature verification
+registry.bindingOf(agentId)      // (sourceCollection, sourceTokenId)
+```
+
+The `erc8004` field is the bridge between the ENS discovery layer (ENSIP-26),
+the verification layer (ENSIP-25), and the on-chain identity layer (ERC-8004).
+
+### The `sanitizationSpec` field
+
+`sanitizationSpec` is an IPFS URI pointing to the specification of the input
+sanitization pipeline applied before the model receives the input. When the
+identity sentinel is used (no sanitization), the value MUST be the URI of the
+identity sentinel specification.
+
+This field is part of the WYRIWE input provenance commitment and enables independent
+verification of the transformation applied between raw input and model input.
+
+### Full example
+
+```json
+{
+  "schema_version": "0.0.1",
+  "name":           "Wizgob NFT #860",
+  "description":    "Goblinarinos Agents",
+  "url":            "https://gateway.ensub.org/agent/0xe61f.../5/mcp",
+  "provider": {
+    "organization": "dinamic.eth",
+    "url":          "https://dinamic.eth.limo"
+  },
+  "version":        "1.0.0",
+  "capabilities": {
+    "streaming":              false,
+    "pushNotifications":      false,
+    "stateTransitionHistory": false
+  },
+  "authentication": {
+    "schemes": ["Bearer"]
+  },
+  "defaultInputModes":  ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "inputSources":    ["user", "system"],
+  "trustScope": {
+    "transitive": false,
+    "maxDepth":   0,
+    "capabilities": []
+  },
+  "sanitizationSpec": "ipfs://QmaYUmRWD33jsmvH9TkMY1TwDgPcZ2zcx5S9BAqCqbUdTr",
+  "erc8004": {
+    "registry": "0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d",
+    "agentId":  "5"
+  },
+  "skills": [
+    {
+      "id":          "chat",
+      "name":        "Chat",
+      "description": "Chat with Wizgob NFT #860",
+      "tags":        ["chat", "conversation"],
+      "examples":    ["Hello, what can you do?"]
+    }
+  ]
+}
+```
+
+Live: `GET https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d/5/.well-known/agent.json`
+
+## Rationale
+
+**Why `/.well-known/agent.json` and not a custom path?**
+RFC 8615 reserves `/.well-known/` for service metadata. This is already the convention
+used by multiple agent frameworks independently. Standardising on it avoids fragmentation.
+
+**Why a separate ENSIP from ENSIP-26?**
+ENSIP-26 explicitly defers schema standardisation to future ENSIPs. This ENSIP is
+that future — it adds schema without changing the discovery mechanism.
+
+**Why `erc8004` as an optional field rather than required?**
+Not every agent will have an on-chain ERC-8004 identity. The field is optional to
+allow offchain-only agents to conform to the schema. When present it SHOULD be treated
+as the authoritative identity anchor.
+
+**Relationship to ENSIP-25**
+ENSIP-25 defines how to verify an ENS name's association with an agent registry entry.
+The `erc8004` field in the agent card is the discovery complement — it tells a client
+where to find the on-chain identity to verify against.
+
+## Backwards Compatibility
+
+Clients unaware of this ENSIP will receive the agent card as an unstructured JSON
+blob. Unknown fields are ignored. Existing gateways serving `/.well-known/agent.json`
+with a subset of the required fields will continue to function — clients SHOULD treat
+missing optional fields as absent rather than erroring.
+
+## Security Considerations
+
+**Gateway trust**: The agent card is served by the gateway. Clients MUST NOT trust
+the `erc8004` field without independently verifying the claimed identity on-chain.
+
+**HTTPS required**: The agent card MUST be served over HTTPS. Clients MUST reject
+agent cards served over plain HTTP.
+
+**`sanitizationSpec` verification**: Clients that verify input provenance MUST fetch
+the spec at the declared IPFS URI and independently compute the pipeline hash rather
+than trusting the gateway's attestation.
+
+## Related
+
+- [ENSIP-25](https://github.com/ensdomains/ensips/blob/main/ensips/25.md) — AI Agent Registry ENS Name Verification
+- [ENSIP-26](https://github.com/ensdomains/ensips/blob/main/ensips/26.md) — Agent Text Records (discovery layer)
+- [ERC-8004](https://ethereum-magicians.org/t/erc-8004-agent-nft-identity-registry) — on-chain agent identity registry
+- [ERC-8217](https://ethereum-magicians.org/t/add-erc-8217-agent-nft-identity-bindings/28339) — agent NFT identity bindings
+- [KYA](https://ethereum-magicians.org/t/draft-erc-universal-ai-inference-verification-registry/28083) — universal AI inference verification registry
+- RFC 8615 — Well-Known URIs
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ensips/27.md
+++ b/ensips/27.md
@@ -191,9 +191,14 @@ allow offchain-only agents to conform to the schema. When present it SHOULD be t
 as the authoritative identity anchor.
 
 **Relationship to ENSIP-25**
-ENSIP-25 defines how to verify an ENS name's association with an agent registry entry.
+[ENSIP-25](https://github.com/ensdomains/ensips/blob/main/ensips/25.md) defines how to verify an ENS name's association with an agent registry entry.
 The `erc8004` field in the agent card is the discovery complement — it tells a client
 where to find the on-chain identity to verify against.
+
+This ENSIP completes the stack alongside [ENSIP-26](https://github.com/ensdomains/ensips/blob/main/ensips/26.md) (discovery layer),
+[ERC-8004](https://ethereum-magicians.org/t/erc-8004-agent-nft-identity-registry) (on-chain identity registry),
+[ERC-8217](https://ethereum-magicians.org/t/add-erc-8217-agent-nft-identity-bindings/28339) (agent NFT identity bindings),
+and [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) (Well-Known URIs).
 
 ## Backwards Compatibility
 
@@ -213,15 +218,6 @@ agent cards served over plain HTTP.
 **`sanitizationSpec` verification**: Clients that verify input provenance MUST fetch
 the spec at the declared IPFS URI and independently compute the pipeline hash rather
 than trusting the gateway's attestation.
-
-## Related
-
-- [ENSIP-25](https://github.com/ensdomains/ensips/blob/main/ensips/25.md) — AI Agent Registry ENS Name Verification
-- [ENSIP-26](https://github.com/ensdomains/ensips/blob/main/ensips/26.md) — Agent Text Records (discovery layer)
-- [ERC-8004](https://ethereum-magicians.org/t/erc-8004-agent-nft-identity-registry) — on-chain agent identity registry
-- [ERC-8217](https://ethereum-magicians.org/t/add-erc-8217-agent-nft-identity-bindings/28339) — agent NFT identity bindings
-- [KYA](https://ethereum-magicians.org/t/draft-erc-universal-ai-inference-verification-registry/28083) — universal AI inference verification registry
-- RFC 8615 — Well-Known URIs
 
 ## Copyright
 

--- a/ensips/agent-card-schema.md
+++ b/ensips/agent-card-schema.md
@@ -9,7 +9,7 @@ ensip:
 track: Ecosystem
 ---
 
-# ENSIP-27: Agent Card Schema
+# ENSIP-X: Agent Card Schema
 
 ## Abstract
 
@@ -52,7 +52,7 @@ where `base-url` is the value of the `agent-endpoint[mcp]` or `agent-endpoint[a2
 text record, or the root of any agent gateway domain. This is the canonical path
 registered by [A2A v0.3.0](https://a2a-protocol.org/v0.3.0/specification/) (the path
 moved from `/.well-known/agent.json` to `/.well-known/agent-card.json` following IANA
-feedback); reusing it keeps ENSIP-27 cards co-located and discoverable by A2A clients.
+feedback); reusing it keeps ENSIP-X cards co-located and discoverable by A2A clients.
 
 A gateway MAY additionally serve the card at the legacy path
 `{base-url}/.well-known/agent.json` (A2A ≤ v0.2.x) as a compatibility alias. When it
@@ -99,11 +99,11 @@ The resource MUST be served over HTTPS and MUST return `Content-Type: applicatio
 `/.well-known/agent-card.json` is also the canonical serving path for [A2A protocol agent
 cards](https://a2a-protocol.org/v0.3.0/specification/) as of v0.3.0 (the earlier
 `/.well-known/agent.json` is A2A ≤ v0.2.x), whose schema is byte-compatible with the
-required fields above — reuse of the path is deliberate and maximises interop. Two fields, however, carry ENSIP-27-specific semantics, and a client
+required fields above — reuse of the path is deliberate and maximises interop. Two fields, however, carry ENSIP-X-specific semantics, and a client
 MUST NOT act on them without first confirming which document class it holds:
 
-- **`schema_version` is the ENSIP-27 discriminator.** A document carrying
-  `protocolVersion` (and no `schema_version`) is an A2A agent card, not an ENSIP-27
+- **`schema_version` is the ENSIP-X discriminator.** A document carrying
+  `protocolVersion` (and no `schema_version`) is an A2A agent card, not an ENSIP-X
   card. A conforming client MUST check `schema_version` before reading `url`.
 - **In this schema, top-level `url` is the agent's MCP endpoint.** In A2A the same key
   is the JSON-RPC endpoint — same key, same type, different transport. A conforming


### PR DESCRIPTION
## Summary

Completes the agent discovery chain defined in ENSIP-26.

ENSIP-26 defines how to find an agent via ENS text records (`agent-endpoint[mcp]`, `agent-endpoint[a2a]`). This ENSIP defines what the agent card document at `/.well-known/agent.json` contains.

- Standardises the `/.well-known/agent.json` schema (required + optional fields)
- Adds `erc8004` identity anchor — bridges ENSIP-25 (verification) + ENSIP-26 (discovery) + ERC-8004 (on-chain identity)
- Adds `sanitizationSpec` for input provenance (WYRIWE)
- Adds `trustScope` for A2A depth limiting
- Security Considerations: gateway trust, HTTPS requirement, provenance verification

## Reference implementation

Live at `gateway.ensub.org` as of 2026-05-19:

```
GET https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d/5/.well-known/agent.json
```

ERC-8004 factory (verified on Etherscan): `0xc2bb6502a7d8ee3cdb2f96508d6cdf426aa2858f`
Three live collection registries on Ethereum mainnet.

## Relationship to existing ENSIPs

| ENSIP | Role |
|---|---|
| ENSIP-25 | Verifies ENS name ↔ agent registry association |
| ENSIP-26 | Discovers agent via `agent-endpoint[*]` text records |
| **ENSIP-27** | Defines what the agent card document contains |

ENSIP-26 explicitly states: *"Future ENSIPs may define more specific formats."* This is that future.

— dinamic.eth