### PR TITLE
ENSIP-26: Add erc8004 identity anchor and agent-endpoint[card] protocol

### DIFF
--- a/ensips/26.md
+++ b/ensips/26.md
@@ -45,7 +45,7 @@ Name owners MAY publish one or more `agent-endpoint` records for different agent
 | `mcp` | [Model Context Protocol](https://modelcontextprotocol.io/) – tools, resources, prompts |
 | `a2a` | [Agent-to-Agent Protocol](https://google-a2a.github.io/A2A/) – agent authentication, skills, messaging |
 | `web` | Web interface or human-facing URL |
-| `card` | Agent card document (ENSIP-27) — full capability and identity manifest |
+| `ens-acs` | ENS Agent Card Schema document (ENSIP-27) — full capability and identity manifest |
 
 Example records:
 

--- a/ensips/26.md
+++ b/ensips/26.md
@@ -45,6 +45,7 @@ Name owners MAY publish one or more `agent-endpoint` records for different agent
 | `mcp` | [Model Context Protocol](https://modelcontextprotocol.io/) – tools, resources, prompts |
 | `a2a` | [Agent-to-Agent Protocol](https://google-a2a.github.io/A2A/) – agent authentication, skills, messaging |
 | `web` | Web interface or human-facing URL |
+| `card` | Agent card document (ENSIP-27) — full capability and identity manifest |
 
 Example records:
 
@@ -91,6 +92,38 @@ My verified tokens for swapping include:
 | WETH   | 10       | 0x4200000000000000000000000000000000000006 |
 | USDC   | 10       | 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85 |
 ```
+
+
+### On-chain identity anchoring in `agent-context`
+
+When an agent is registered in an ERC-8004 agent identity registry, the `agent-context`
+value MAY include an `erc8004` object to link the ENS name to the agent's on-chain identity:
+
+```json
+{
+  "erc8004": {
+    "registry": "0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d",
+    "agentId":  "5"
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `registry` | ERC-8004 registry contract address |
+| `agentId` | Token ID of the agent within the registry |
+
+Clients that support ERC-8004 SHOULD use this field to confirm the agent's on-chain
+identity before trusting the declared endpoints:
+
+```solidity
+registry.ownerOf(agentId)        // confirms agent exists
+registry.getAgentWallet(agentId) // hot wallet for A2A request signing (see ENSIP-27)
+registry.bindingOf(agentId)      // (sourceCollection, sourceTokenId)
+```
+
+This field bridges ENSIP-26 (discovery), ENSIP-25 (verification), and ERC-8004
+(on-chain identity) into a single resolution flow.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary

Two additive contributions to ENSIP-26 backed by a live production implementation.

### 1. `erc8004` field in `agent-context`

Adds a standard sub-field for agents registered in an ERC-8004 identity registry:

```json
{
  "erc8004": {
    "registry": "0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d",
    "agentId":  "5"
  }
}
```

Enables verifiers to confirm on-chain identity (`ownerOf`, `getAgentWallet`, `bindingOf`) without trusting the gateway. Bridges ENSIP-25 (verification) + ENSIP-26 (discovery) + ERC-8004 (identity) into one resolution flow.

### 2. `agent-endpoint[card]` protocol value

Adds `card` to the defined `agent-endpoint` protocol table — points to an ENSIP-27 agent card document (`/.well-known/agent.json`) containing the full capability and identity manifest.

## Reference implementation

Both live at `gateway.ensub.org` as of 2026-05-19:

- Live agent card: `https://gateway.ensub.org/agent/0xe61f5a6783ae09949b9a1b6821b68f89c0d7bb2d/5/.well-known/agent.json`
- ERC-8004 factory (verified): `0xc2bb6502a7d8ee3cdb2f96508d6cdf426aa2858f`
- Three live registries on Ethereum mainnet

## Related

- Companion PR: #75 (ENSIP-27 — Agent Card Schema)
- ENSIP-25 — AI Agent Registry ENS Name Verification

— dinamic.eth