### PR TITLE
Adjust app regex to support arbitrary inline inclusions

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -158,7 +158,7 @@ async function inlineSubdirectoryFiles(
     filePath: string
 ): Promise<string> {
     // Matches [](./NUMBER/file.md) — content inclusion directives
-    const subfileLink = /^\[\]\(\.\/\d+\/([^)]+\.md)\)$/gm;
+    const subfileLink = /\[\]\(\.\/\d+\/([^)]+\.md)\)/gm;
     const dir = filePath.replace(/[^/]+$/, '');
     const ensipNumber = filePath.match(/(\d+)\.md$/)?.[1];
     if (!ensipNumber) return markdown;


### PR DESCRIPTION
Removes line anchors (`^`/`$`) from the subdirectory file inclusion regex so `[](./N/file.md)` works both as a standalone line (e.g. inlining a table) and mid-line (e.g. inlining a version string).