### PR TITLE
Fix broken link to ENSIP-1 registry specification in ENSIP-23

### DIFF
--- a/ensips/23.md
+++ b/ensips/23.md
@@ -104,7 +104,7 @@ interface IUniversalResolver {
 
 ### findResolver
 
-This function performs onchain [registry traversal](./#registry-specification) of a DNS-encoded `name`.  It returns the first non-null `resolver` address, the namehash of `name` as `node`, and the `resolverOffset` into `name` that corresponds to the resolver.  If no resolver is found, `resolver` is null.
+This function performs onchain [registry traversal](./1.md#registry-specification) of a DNS-encoded `name`.  It returns the first non-null `resolver` address, the namehash of `name` as `node`, and the `resolverOffset` into `name` that corresponds to the resolver.  If no resolver is found, `resolver` is null.
 
 `findResolver()` does not perform any validity checks on the resolver and simply returns the value in the registry.  The resolver may not be a contract or a resolver.
 


### PR DESCRIPTION
Fixes dead link in `findResolver` section: `./#registry-specification` pointed to a non-existent anchor on the current page. Changed to `./1.md#registry-specification` to correctly link to ENSIP-1's Registry specification.