### PR TITLE
Add ENSIP-28: ENS Name Owned Accounts

### DIFF
--- a/ensips/28.md
+++ b/ensips/28.md
@@ -1,8 +1,9 @@
 ---
 title: ENS Name Owned Accounts
-description: A method for an ENS name to list additional accounts per chain as data records
+description: A method for an ENS name to list accounts per chain and for each account to prove it consents to the association
 contributors:
   - premm.eth
+  - workemon.eth
 ensip:
   created: "2026-08-13"
   status: draft
@@ -12,11 +13,13 @@ ensip:
 
 ## Abstract
 
-This ENSIP lets an ENS name list more than one account per chain, for example a Safe or a token-bound account. A listing is a claim by the name owner and proves nothing about the account. Verification may be defined in a future ENSIP or a future draft revision of ENSIP-28.
+This ENSIP lets an ENS name list more than one account per chain, for example a Safe or a token bound account, and requires each listed account to prove that it consents to the association. The proof is a signature over an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed message, stored as a data record alongside the listing. It covers EOAs, deployed smart accounts (via [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271)), and token bound accounts ([ERC-6551](https://eips.ethereum.org/EIPS/eip-6551)).
 
 ## Motivation
 
-ENS names often represent a user identity, for both human users and AI agents. A user frequently controls more than one account on a chain and wants those accounts associated with a single ENS name. No standard exists for that association today. This ENSIP lets a name declare additional accounts per chain.
+ENS names often represent a user identity, for both human users and AI agents. A user frequently controls more than one account on a chain and wants those accounts associated with a single ENS name. [ENSIP-9](./9.md) resolves one address per chain, which suits a payment address but not an identity that spans several accounts.
+
+An association is only meaningful if both sides agree to it. A record written by the name owner alone is a claim about someone else's account, and anyone who controls a name can name any address in it. This ENSIP therefore defines both halves: how a name lists its accounts, and how each account proves that it consents to being listed.
 
 ## Specification
 
@@ -24,60 +27,145 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Account Data Records
 
-An ENS name MAY list additional accounts as [ENSIP-24](./24.md) data records on its own node under the reserved key:
+An ENS name lists its accounts on a chain as an [ENSIP-24](./24.md) data record on its own node under the reserved key:
 
 ```
-account[<chain-id>][<index>]
+accounts[<chain-id>]
 ```
 
-Where:
+where `<chain-id>` is the EVM chain ID as an unsigned base-10 integer without leading zeros.
 
-- `<chain-id>` is the ERC-7930 Chain Identifier, a lowercase `0x`-prefixed hex string,
-- `<index>` is an unsigned base-10 integer without leading zeros, distinguishing multiple accounts on the same chain.
+The value MUST be the accounts encoded as consecutive 32-byte words, each holding an address in its low 20 bytes:
 
-The value MUST be the Address component of an ERC-7930 Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, this is the 20-byte address.
+```
+abi.encode(address account1, address account2, ...)
+```
 
-Indexes MAY be assigned in any order. Clients MAY discover keys through `supportedDataKeys` or `DataChanged` events, both defined in [ENSIP-24](./24.md).
+The number of accounts is the length of the value divided by 32. Accounts MAY appear in any order. A record MUST NOT list more than 32 accounts, and clients MUST ignore any beyond the first 32.
 
-Any account MAY be listed.
+A name MAY additionally publish the chains it has accounts on under the reserved key:
+
+```
+accounts-chains
+```
+
+whose value MUST be `abi.encode(uint256 chainId1, uint256 chainId2, ...)`. Clients MAY instead discover keys by indexing `DataChanged` events, defined in [ENSIP-24](./24.md).
+
+### Proof Data Records
+
+The proofs for the accounts listed under `accounts[<chain-id>]` are stored on the same node under the reserved key:
+
+```
+accounts-proofs[<chain-id>]
+```
+
+with the same `<chain-id>` as the listing it proves. The value MUST be:
+
+```
+abi.encode(Proof[] proofs)
+
+struct Proof {
+    address account;   // the listed account this proof is for
+    uint64  expiresAt; // Unix timestamp in seconds, non-zero
+    bytes   signature; // over the Consent message below
+}
+```
+
+Each account listed in `accounts[<chain-id>]` MUST have exactly one entry whose `account` field equals it. Entries whose `account` is not listed MUST be ignored, and entries MAY appear in any order.
+
+`expiresAt` is a Unix timestamp in seconds and MUST be non-zero. The proof is invalid at and after that time, and is valid for at most the two years preceding it. Until a proof lapses, an account cannot withdraw consent unilaterally, and removal rests with the name owner. Signers SHOULD choose the shortest window that suits the association.
+
+`signature` is a signature over the message defined below. It MUST NOT be empty. A listed account MUST therefore be able to produce an ECDSA signature or to validate one under ERC-1271. A contract account MUST be deployed before it can be listed. A token bound account is deployed through the ERC-6551 registry's `createAccount`.
+
+### Consent Message
+
+The signature MUST be over the following EIP-712 typed data:
+
+```
+domain = {
+    name:    "ENS Name Owned Accounts",
+    version: "1",
+    chainId: <the chain the name's records are on>
+}
+
+struct Consent {
+    bytes32 node;           // namehash of the listing ENS name
+    uint256 accountChainId; // the chain the listed account is on
+    address account;        // the listed account
+    uint64  expiresAt;      // must equal the entry's expiresAt
+}
+```
+
+The `Consent` type hash is `0x7a35aa0efd9ea4a4b01d17a2e6fcc166eb2be65384757262fc2329986e5497f5`. The domain type hash, over `EIP712Domain(string name,string version,uint256 chainId)`, is `0xc2f8787176b8ac6bf7215b4adcc1e069bf4ab82d9ab1df05a57a91d425935b6e`, which gives these domain separators:
+
+| Chain | `chainId` | Domain separator |
+| --- | --- | --- |
+| Ethereum Mainnet | `1` | `0xefbd5fd6831eeaf1b039217878898cb25c5afb12a1789321e1e4b870d56bdab0` |
+| Sepolia | `11155111` | `0x0e8de794261382cbb6e04b05bebc36d7e32e3461ee7f992d81fb7236a1419cd6` |
+
+The domain's `chainId` is the chain the name's records are on. It binds a proof to one ENS deployment, so a proof signed against a name in one deployment does not verify against the same name in another.
+
+The domain contains no `verifyingContract`. These proofs are not verified by any one contract, so there is nothing for it to name, and its absence lets a proof survive a migration of the name's records to a new resolver.
+
+### Verification
+
+To determine a name's accounts on a chain, a client:
+
+1. Reads `accounts[<chain-id>]` and decodes it as consecutive 32-byte words, each holding an address in its low 20 bytes. Reads `accounts-proofs[<chain-id>]` and decodes it as `Proof[]`.
+2. For each listed account, selects the single entry whose `account` equals it. An account with no entry, or with more than one, is not verified.
+3. Rejects the entry if `expiresAt` is zero, if `signature` is empty, if the current time is at or past `expiresAt`, or if `expiresAt` is more than two years after the current time. A verifier running on chain uses `block.timestamp` as the current time.
+4. Reconstructs the `Consent` struct, taking `node` from the name being resolved, `accountChainId` from the record key, and `account` and `expiresAt` from the entry. Computes the EIP-712 digest, taking the domain `chainId` from the chain the name's records were resolved from, and validates `signature` for the listed account on the chain named by `<chain-id>`. Validation MUST be attempted in this order:
+   1. If the account has code, validate it by calling `isValidSignature` (ERC-1271) on the account. Validation succeeds only if the call returns the ERC-1271 magic value `0x1626ba7e`. A revert, or any other return value, is a failure of that account's verification and MUST NOT affect any other account.
+   2. Otherwise, validate it by `ecrecover`. Recovery of the zero address is a failure.
+
+Each account is verified independently. An account that fails any step is not an owned account of the name, and clients MUST NOT present it as one. Because the struct is reconstructed from context, a proof copied to another name, chain, account, or ENS deployment fails verification.
 
 ### Relation to Address Records
 
 The name's address records under [ENSIP-1](./1.md) and [ENSIP-9](./9.md) continue to resolve its primary accounts. Listed accounts are data records, not address records.
 
-### Meaning of a Listing
+### Meaning of a Verified Owned Account
 
-A listing is a claim by the name owner and is not verified. Anyone who controls a name can list any address. Clients MUST NOT treat a listing as evidence that the name owner controls the account, that the account consents to the association, or that the account is any particular kind of account.
+A listed account becomes a verified owned account of the name when its proof verifies. Both sides have then acted: the name owner wrote the listing, and the account authorised a signature consenting to it.
 
-Clients and explorers MUST NOT display the listing ENS name in place of the account address on the basis of a listing. Clients SHOULD NOT send funds to a listed account. The name's address records remain its payment addresses.
-
-Verifying the link between a name and a listed account is out of scope. A verification system may be defined in a future ENSIP or a future draft revision of ENSIP-28.
+An owned account is not a payment address. Clients and explorers MUST NOT display the ENS name in place of the account address, and clients SHOULD NOT send funds to an owned account. The name's address records remain its payment addresses.
 
 ### Ethereum Example
 
-The name `agent.example.eth` lists an account on Ethereum mainnet, Chain Identifier `0x00010000010100`, at index 0:
+The name `agent.example.eth` lists two accounts on Ethereum mainnet, chain ID `1`:
 
-- `data(namehash("agent.example.eth"), "account[0x00010000010100][0]")` returns `0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5`.
+```
+data(namehash("agent.example.eth"), "accounts[1]") =
+  0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045
+    000000000000000000000000b8c2c29ee19d8307cb7255e1cd9cbde883a267d5
+```
+
+The proofs for those accounts, both expiring at `1798761600` (2027-01-01):
+
+```
+data(namehash("agent.example.eth"), "accounts-proofs[1]") = abi.encode([
+  (0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045, 1798761600, 0x...),
+  (0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5, 1798761600, 0x...)
+])
+```
 
 ## Rationale
 
-Users of ENS names, including AI agents, commonly hold more than one account. [ENSIP-24](./24.md) resolves raw bytes from a name, and ERC-7930 encodes a chain and an address in one compact binary format. Together they carry an account listing without introducing any new resolver profile method. ERC-7930 was chosen because it names chains beyond EVM and defines an upgrade path for future address formats.
-
-Verification was considered and deferred. The obvious mechanism, setting the account's reverse record to the listing name, was rejected because the reverse record also carries the account's primary name, so an account could not be verifiable and hold its own primary name at the same time. A separate system may instead be specified in a future ENSIP or a future draft revision of ENSIP-28.
-
-The title says owned because these accounts belong to the name rather than receive payment for it. Proving ownership is out of scope.
+- **One signature scheme for all signing accounts.** EIP-712 signatures verify by `ecrecover` for EOAs and via ERC-1271 for contract accounts, including ERC-6551 token bound accounts, which are required to implement ERC-1271 and by default treat the holder of the bound NFT as a valid signer. Standard library functions already implement this cascade, for example OpenZeppelin's `SignatureChecker`, so clients need one code path.
+- **The account is bound inside the struct.** ERC-1271 only answers whether a digest is validly signed for a given account, and one signing key often controls several accounts. Without `account` in the struct, a consent signed for one account would verify for every account under the same signer. Binding `accountChainId` likewise stops a proof for a contract at a given address on one chain from verifying the same address on another.
+- **Expiry is what makes consent withdrawable.** A signature cannot be unsigned, so a required `expiresAt` is what gives an account a way out: it stops renewing and the listing lapses within a window of at most two years. ERC-1271 proofs additionally stop verifying when the account rotates its signers, which for an ERC-6551 account means a proof lapses when the owning token is transferred.
 
 ## Backwards Compatibility
 
-This ENSIP requires no change to existing resolution standards.
+This ENSIP requires no change to existing resolution standards and introduces no new resolver profile method.
 
 ## Security Considerations
 
-A listing is controlled by the name owner alone and can name accounts belonging to others. Clients that present listings SHOULD label them as unverified claims.
-
-If the name is transferred, listings set by the previous owner remain until changed.
-
-A listing carries no payment endorsement. Funds sent to a listed account may be unrecoverable, for example when a contract account does not exist at the same address on another chain.
+- Proofs survive a transfer of the ENS name, so an owned account consented to the name, not to its current owner. Bounded validity windows mitigate this.
+- A proof shows that the account's signer consented to the association, not that the name and the account are controlled by the same party. Two cooperating parties can produce the same records.
+- An account delegated under [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) has code, so it is verified through its delegate under ERC-1271. Such an account can be listed only while its delegate implements ERC-1271, and changing the delegate can stop existing proofs from verifying.
+- A token bound account validates signatures against the current holder of its bound token, which it can read only on its own chain. An account bound to a token on another chain cannot be listed.
+- Verification cost scales with a list the name owner controls, and a name served from an offchain resolver costs its owner nothing to publish.
 
 ## Copyright
 

--- a/ensips/28.md
+++ b/ensips/28.md
@@ -8,11 +8,11 @@ ensip:
   status: draft
 ---
 
-# ENSIP-X: ENS Name Owned Accounts
+# ENSIP-28: ENS Name Owned Accounts
 
 ## Abstract
 
-This ENSIP lets an ENS name list more than one account per chain, for example a Safe or a token-bound account. A listing is a claim by the name owner and proves nothing about the account. Verifying the link between a name and a listed account is left to a future ENSIP.
+This ENSIP lets an ENS name list more than one account per chain, for example a Safe or a token-bound account. A listing is a claim by the name owner and proves nothing about the account. Verification may be defined in a future ENSIP or a future draft revision of ENSIP-28.
 
 ## Motivation
 
@@ -51,7 +51,7 @@ A listing is a claim by the name owner and is not verified. Anyone who controls 
 
 Clients and explorers MUST NOT display the listing ENS name in place of the account address on the basis of a listing. Clients SHOULD NOT send funds to a listed account. The name's address records remain its payment addresses.
 
-Verifying the link between a name and a listed account is out of scope. A future ENSIP will define a verification system.
+Verifying the link between a name and a listed account is out of scope. A verification system may be defined in a future ENSIP or a future draft revision of ENSIP-28.
 
 ### Ethereum Example
 
@@ -61,9 +61,9 @@ The name `agent.example.eth` lists an account on Ethereum mainnet, Chain Identif
 
 ## Rationale
 
-Users of ENS names, including AI agents, commonly hold more than one account, and two recent standards make storing those accounts on a name efficient. [ENSIP-24](./24.md) resolves raw bytes from a name, and ERC-7930 encodes a chain and an address in one compact binary format. Together they carry an account listing without introducing any new resolver profile method. ERC-7930 was chosen because it is built to outlast current addressing practice. It names chains beyond EVM and defines an upgrade path for future address formats.
+Users of ENS names, including AI agents, commonly hold more than one account. [ENSIP-24](./24.md) resolves raw bytes from a name, and ERC-7930 encodes a chain and an address in one compact binary format. Together they carry an account listing without introducing any new resolver profile method. ERC-7930 was chosen because it names chains beyond EVM and defines an upgrade path for future address formats.
 
-Verification was considered and deferred. The obvious mechanism, setting the account's reverse record to the listing name, was rejected because the reverse record also carries the account's primary name, so an account could not be verifiable and hold its own primary name at the same time. A future ENSIP will define a separate system.
+Verification was considered and deferred. The obvious mechanism, setting the account's reverse record to the listing name, was rejected because the reverse record also carries the account's primary name, so an account could not be verifiable and hold its own primary name at the same time. A separate system may instead be specified in a future ENSIP or a future draft revision of ENSIP-28.
 
 The title says owned because these accounts belong to the name rather than receive payment for it. Proving ownership is out of scope.
 

--- a/ensips/28.md
+++ b/ensips/28.md
@@ -4,6 +4,7 @@ description: A method for an ENS name to list accounts per chain and for each ac
 contributors:
   - premm.eth
   - workemon.eth
+  - raffy.eth
 ensip:
   created: "2026-08-13"
   status: draft
@@ -53,25 +54,19 @@ whose value MUST be `abi.encode(uint256 chainId1, uint256 chainId2, ...)`. Clien
 
 ### Proof Data Records
 
-The proofs for the accounts listed under `accounts[<chain-id>]` are stored on the same node under the reserved key:
+The proof for an account listed under `accounts[<chain-id>]` is stored on the same node under the reserved key:
 
 ```
-accounts-proofs[<chain-id>]
+accounts[<chain-id>][<account>]
 ```
 
-with the same `<chain-id>` as the listing it proves. The value MUST be:
+with the same `<chain-id>` as the listing it proves, and where `<account>` is `0x` followed by the lowercase hexadecimal representation of the listed account's address bytes. The value MUST be:
 
 ```
-abi.encode(Proof[] proofs)
-
-struct Proof {
-    address account;   // the listed account this proof is for
-    uint64  expiresAt; // Unix timestamp in seconds, non-zero
-    bytes   signature; // over the Consent message below
-}
+abi.encode(uint256 expiresAt, bytes signature)
 ```
 
-Each account listed in `accounts[<chain-id>]` MUST have exactly one entry whose `account` field equals it. Entries whose `account` is not listed MUST be ignored, and entries MAY appear in any order.
+Each account listed in `accounts[<chain-id>]` MUST have a record at its key. An account whose record is absent or empty is not verified.
 
 `expiresAt` is a Unix timestamp in seconds and MUST be non-zero. The proof is invalid at and after that time, and is valid for at most the two years preceding it. Until a proof lapses, an account cannot withdraw consent unilaterally, and removal rests with the name owner. Signers SHOULD choose the shortest window that suits the association.
 
@@ -92,11 +87,11 @@ struct Consent {
     bytes32 node;           // namehash of the listing ENS name
     uint256 accountChainId; // the chain the listed account is on
     address account;        // the listed account
-    uint64  expiresAt;      // must equal the entry's expiresAt
+    uint256 expiresAt;      // must equal the record's expiresAt
 }
 ```
 
-The `Consent` type hash is `0x7a35aa0efd9ea4a4b01d17a2e6fcc166eb2be65384757262fc2329986e5497f5`. The domain type hash, over `EIP712Domain(string name,string version,uint256 chainId)`, is `0xc2f8787176b8ac6bf7215b4adcc1e069bf4ab82d9ab1df05a57a91d425935b6e`, which gives these domain separators:
+The `Consent` type hash is `0x8dff32c14409d396587044aa7663b77f60b1d374ec13710f3f0acdc3a810a94d`. The domain type hash, over `EIP712Domain(string name,string version,uint256 chainId)`, is `0xc2f8787176b8ac6bf7215b4adcc1e069bf4ab82d9ab1df05a57a91d425935b6e`, which gives these domain separators:
 
 | Chain | `chainId` | Domain separator |
 | --- | --- | --- |
@@ -111,10 +106,10 @@ The domain contains no `verifyingContract`. These proofs are not verified by any
 
 To determine a name's accounts on a chain, a client:
 
-1. Reads `accounts[<chain-id>]` and decodes it as consecutive 32-byte words, each holding an address in its low 20 bytes. Reads `accounts-proofs[<chain-id>]` and decodes it as `Proof[]`.
-2. For each listed account, selects the single entry whose `account` equals it. An account with no entry, or with more than one, is not verified.
-3. Rejects the entry if `expiresAt` is zero, if `signature` is empty, if the current time is at or past `expiresAt`, or if `expiresAt` is more than two years after the current time. A verifier running on chain uses `block.timestamp` as the current time.
-4. Reconstructs the `Consent` struct, taking `node` from the name being resolved, `accountChainId` from the record key, and `account` and `expiresAt` from the entry. Computes the EIP-712 digest, taking the domain `chainId` from the chain the name's records were resolved from, and validates `signature` for the listed account on the chain named by `<chain-id>`. Validation MUST be attempted in this order:
+1. Reads `accounts[<chain-id>]` and decodes it as consecutive 32-byte words, each holding an address in its low 20 bytes.
+2. For each listed account, reads `accounts[<chain-id>][<account>]` and decodes it as `(uint256 expiresAt, bytes signature)`. An account whose record is absent or empty is not verified.
+3. Rejects the record if `expiresAt` is zero, if `signature` is empty, if the current time is at or past `expiresAt`, or if `expiresAt` is more than two years after the current time. A verifier running on chain uses `block.timestamp` as the current time.
+4. Reconstructs the `Consent` struct, taking `node` from the name being resolved, `accountChainId` from the record key, `account` from the listed account, and `expiresAt` from the record. Computes the EIP-712 digest, taking the domain `chainId` from the chain the name's records were resolved from, and validates `signature` for the listed account on the chain named by `<chain-id>`. Validation MUST be attempted in this order:
    1. If the account has code, validate it by calling `isValidSignature` (ERC-1271) on `account`. Validation succeeds only if the call returns the ERC-1271 magic value `0x1626ba7e`. A revert, or any other return value, is a failure of that account's verification and MUST NOT affect any other account.
    2. Otherwise, validate it by `ecrecover`. Validation succeeds only if the recovered address equals `account` and is not the zero address.
 
@@ -143,10 +138,13 @@ data(namehash("agent.example.eth"), "accounts[1]") =
 The proofs for those accounts, both expiring at `1798761600` (2027-01-01):
 
 ```
-data(namehash("agent.example.eth"), "accounts-proofs[1]") = abi.encode([
-  (0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045, 1798761600, 0x...),
-  (0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5, 1798761600, 0x...)
-])
+data(namehash("agent.example.eth"),
+     "accounts[1][0xd8da6bf26964af9d7eed9e03e53415d37aa96045]")
+  = abi.encode(uint256(1798761600), 0x...)
+
+data(namehash("agent.example.eth"),
+     "accounts[1][0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5]")
+  = abi.encode(uint256(1798761600), 0x...)
 ```
 
 ## Rationale
@@ -165,7 +163,6 @@ This ENSIP requires no change to existing resolution standards and introduces no
 - A proof shows that the account's signer consented to the association, not that the name and the account are controlled by the same party. Two cooperating parties can produce the same records.
 - An account delegated under [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) has code, so it is verified through its delegate under ERC-1271. Such an account can be listed only while its delegate implements ERC-1271, and changing the delegate can stop existing proofs from verifying.
 - A token bound account validates signatures against the current holder of its bound token, which it can read only on its own chain. An account bound to a token on another chain cannot be listed.
-- Verification cost scales with a list the name owner controls, and a name served from an offchain resolver costs its owner nothing to publish.
 
 ## Copyright
 

--- a/ensips/28.md
+++ b/ensips/28.md
@@ -115,8 +115,8 @@ To determine a name's accounts on a chain, a client:
 2. For each listed account, selects the single entry whose `account` equals it. An account with no entry, or with more than one, is not verified.
 3. Rejects the entry if `expiresAt` is zero, if `signature` is empty, if the current time is at or past `expiresAt`, or if `expiresAt` is more than two years after the current time. A verifier running on chain uses `block.timestamp` as the current time.
 4. Reconstructs the `Consent` struct, taking `node` from the name being resolved, `accountChainId` from the record key, and `account` and `expiresAt` from the entry. Computes the EIP-712 digest, taking the domain `chainId` from the chain the name's records were resolved from, and validates `signature` for the listed account on the chain named by `<chain-id>`. Validation MUST be attempted in this order:
-   1. If the account has code, validate it by calling `isValidSignature` (ERC-1271) on the account. Validation succeeds only if the call returns the ERC-1271 magic value `0x1626ba7e`. A revert, or any other return value, is a failure of that account's verification and MUST NOT affect any other account.
-   2. Otherwise, validate it by `ecrecover`. Recovery of the zero address is a failure.
+   1. If the account has code, validate it by calling `isValidSignature` (ERC-1271) on `account`. Validation succeeds only if the call returns the ERC-1271 magic value `0x1626ba7e`. A revert, or any other return value, is a failure of that account's verification and MUST NOT affect any other account.
+   2. Otherwise, validate it by `ecrecover`. Validation succeeds only if the recovered address equals `account` and is not the zero address.
 
 Each account is verified independently. An account that fails any step is not an owned account of the name, and clients MUST NOT present it as one. Because the struct is reconstructed from context, a proof copied to another name, chain, account, or ENS deployment fails verification.
 

--- a/ensips/28.md
+++ b/ensips/28.md
@@ -42,7 +42,7 @@ The value MUST be the accounts encoded as consecutive 32-byte words, each holdin
 abi.encode(address account1, address account2, ...)
 ```
 
-The number of accounts is the length of the value divided by 32. Accounts MAY appear in any order. A record MUST NOT list more than 32 accounts, and clients MUST ignore any beyond the first 32.
+The number of accounts is the length of the value divided by 32. Accounts MAY appear in any order.
 
 A name MAY additionally publish the chains it has accounts on under the reserved key:
 

--- a/ensips/28.md
+++ b/ensips/28.md
@@ -8,6 +8,7 @@ contributors:
 ensip:
   created: "2026-08-13"
   status: draft
+track: Ecosystem
 ---
 
 # ENSIP-28: ENS Name Owned Accounts

--- a/ensips/ens-name-owned-accounts.md
+++ b/ensips/ens-name-owned-accounts.md
@@ -1,0 +1,84 @@
+---
+title: ENS Name Owned Accounts
+description: A method for an ENS name to list additional accounts per chain as data records
+contributors:
+  - premm.eth
+ensip:
+  created: "2026-08-13"
+  status: draft
+---
+
+# ENSIP-X: ENS Name Owned Accounts
+
+## Abstract
+
+This ENSIP lets an ENS name list more than one account per chain, for example a Safe or a token-bound account. A listing is a claim by the name owner and proves nothing about the account. Verifying the link between a name and a listed account is left to a future ENSIP.
+
+## Motivation
+
+ENS names often represent a user identity, for both human users and AI agents. A user frequently controls more than one account on a chain and wants those accounts associated with a single ENS name. No standard exists for that association today. This ENSIP lets a name declare additional accounts per chain.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Account Data Records
+
+An ENS name MAY list additional accounts as [ENSIP-24](./24.md) data records on its own node under the reserved key:
+
+```
+account[<chain-id>][<index>]
+```
+
+Where:
+
+- `<chain-id>` is the ERC-7930 Chain Identifier, a lowercase `0x`-prefixed hex string,
+- `<index>` is an unsigned base-10 integer without leading zeros, distinguishing multiple accounts on the same chain.
+
+The value MUST be the Address component of an ERC-7930 Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, this is the 20-byte address.
+
+Indexes MAY be assigned in any order. Clients MAY discover keys through `supportedDataKeys` or `DataChanged` events, both defined in [ENSIP-24](./24.md).
+
+Any account MAY be listed.
+
+### Relation to Address Records
+
+The name's address records under [ENSIP-1](./1.md) and [ENSIP-9](./9.md) continue to resolve its primary accounts. Listed accounts are data records, not address records.
+
+### Meaning of a Listing
+
+A listing is a claim by the name owner and is not verified. Anyone who controls a name can list any address. Clients MUST NOT treat a listing as evidence that the name owner controls the account, that the account consents to the association, or that the account is any particular kind of account.
+
+Clients and explorers MUST NOT display the listing ENS name in place of the account address on the basis of a listing. Clients SHOULD NOT send funds to a listed account. The name's address records remain its payment addresses.
+
+Verifying the link between a name and a listed account is out of scope. A future ENSIP will define a verification system.
+
+### Ethereum Example
+
+The name `agent.example.eth` lists an account on Ethereum mainnet, Chain Identifier `0x00010000010100`, at index 0:
+
+- `data(namehash("agent.example.eth"), "account[0x00010000010100][0]")` returns `0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5`.
+
+## Rationale
+
+Users of ENS names, including AI agents, commonly hold more than one account, and two recent standards make storing those accounts on a name efficient. [ENSIP-24](./24.md) resolves raw bytes from a name, and ERC-7930 encodes a chain and an address in one compact binary format. Together they carry an account listing without introducing any new resolver profile method. ERC-7930 was chosen because it is built to outlast current addressing practice. It names chains beyond EVM and defines an upgrade path for future address formats.
+
+Verification was considered and deferred. The obvious mechanism, setting the account's reverse record to the listing name, was rejected because the reverse record also carries the account's primary name, so an account could not be verifiable and hold its own primary name at the same time. A future ENSIP will define a separate system.
+
+The title says owned because these accounts belong to the name rather than receive payment for it. Proving ownership is out of scope.
+
+## Backwards Compatibility
+
+This ENSIP requires no change to existing resolution standards.
+
+## Security Considerations
+
+A listing is controlled by the name owner alone and can name accounts belonging to others. Clients that present listings SHOULD label them as unverified claims.
+
+If the name is transferred, listings set by the previous owner remain until changed.
+
+A listing carries no payment endorsement. Funds sent to a listed account may be unrecoverable, for example when a contract account does not exist at the same address on another chain.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Lets an ENS name list additional accounts per chain as [ENSIP-24](https://docs.ens.domains/ensip/24) data records under the reserved key `account[<chain-id>][<index>]`. The value is the ERC-7930 Address component for the chain named by the key, so no new resolver profile method is needed.

A listing is a claim by the name owner and is not verified. Verification is out of scope and left to a future ENSIP. The obvious mechanism, setting the account's reverse record to the name, was rejected because that record also carries the account's primary name, so an account could not be verifiable and keep its own primary name.

The file is named descriptively and is ready to be renamed to its assigned number.
